### PR TITLE
#77 - center Google "G" icon

### DIFF
--- a/resources/js/Pages/Login.vue
+++ b/resources/js/Pages/Login.vue
@@ -47,7 +47,7 @@
     >
     <a
       href="/login/google/start"
-      class="inline-flex justify-center py-2 px-6 rounded-md shadow-sm bg-blumilk-500 text-md font-medium text-white hover:bg-blumilk-700"
+      class="inline-flex justify-center items-center py-2 px-6 rounded-md shadow-sm bg-blumilk-500 text-md font-medium text-white hover:bg-blumilk-700"
     >
       Zaloguj się za pomocą Google
       <svg


### PR DESCRIPTION
Fixes #77

![image](https://user-images.githubusercontent.com/16743001/158398818-109dadf9-185e-4be0-bedb-5544226c39cb.png)
