### PR TITLE
#48 - fix heroku deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: vendor/bin/heroku-php-nginx -C environment/prod/nginx.conf public/
-release: php artisan migrate --force && php artisan cache:clear && php artisan config:cache
+release: php artisan config:cache && php artisan route:cache && php artisan migrate --force
 worker: php artisan queue:work


### PR DESCRIPTION
I changed the order of commands due to problems with credentials during release phase on heroku.