### PR TITLE
#115 - Heroku deploy in GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,17 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.12.12
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: ${{secrets.HEROKU_APP_NAME}}
+          heroku_email: ${{secrets.HEROKU_EMAIL}}

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "spatie/laravel-slack-slash-command": "^1.11"
     },
     "require-dev": {
-        "blumilksoftware/codestyle": "^1.0.0",
+        "blumilksoftware/codestyle": "^1.2.0",
         "fakerphp/faker": "^1.19",
         "laravel/dusk": "^6.21",
         "mockery/mockery": "^1.4.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "24a1b3a5dd7c4d4f50d521dda4b6654e",
+    "content-hash": "572998c0dff042cc8ddf65cb1b7348c9",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7652,16 +7652,16 @@
     "packages-dev": [
         {
             "name": "blumilksoftware/codestyle",
-            "version": "v1.1.0",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/blumilksoftware/codestyle.git",
-                "reference": "3f2248859562afe7d7b2b16aa25e83dc73236fcc"
+                "reference": "124c55f0374d8f6952675011e359cb54f40f4090"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/blumilksoftware/codestyle/zipball/3f2248859562afe7d7b2b16aa25e83dc73236fcc",
-                "reference": "3f2248859562afe7d7b2b16aa25e83dc73236fcc",
+                "url": "https://api.github.com/repos/blumilksoftware/codestyle/zipball/124c55f0374d8f6952675011e359cb54f40f4090",
+                "reference": "124c55f0374d8f6952675011e359cb54f40f4090",
                 "shasum": ""
             },
             "require": {
@@ -7696,9 +7696,9 @@
             "description": "Blumilk codestyle configurator",
             "support": {
                 "issues": "https://github.com/blumilksoftware/codestyle/issues",
-                "source": "https://github.com/blumilksoftware/codestyle/tree/v1.1.0"
+                "source": "https://github.com/blumilksoftware/codestyle/tree/v1.2.0"
             },
-            "time": "2022-04-25T06:04:51+00:00"
+            "time": "2022-04-27T10:13:34+00:00"
         },
         {
             "name": "composer/pcre",


### PR DESCRIPTION
This should close #115 and allow us to deploy application from Github. This is a suggested way of deploy after recent Github/Heroku security issues.

Heroku deploy should be triggered for every release with name starting with "v", eg. "v1.0.0".

Secrets were added to the repository: 
![obraz](https://user-images.githubusercontent.com/10898728/165893995-7c1ef088-0b29-4ba4-b6fe-502ef330b3c4.png)
