### PR TITLE
- restricting PR approvals for code owners only

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @blumilksoftware/toby


### PR DESCRIPTION
With outside collaborators workong on this project, I would like restrict PR approval workflow. After these changes at least one approval from someone from @blumilksoftware/toby will be required to greenlit a pull request.