### PR TITLE
- GHA workflows adjustments

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -5,8 +5,8 @@ on:
       - opened
       - edited
       - synchronize
-      - labeled
-      - unlabeled
+      - ready_for_review
+      - reopened
 
 jobs:
   check-pr-title:

--- a/.github/workflows/test-and-lint-js.yml
+++ b/.github/workflows/test-and-lint-js.yml
@@ -2,7 +2,13 @@ name: Test & lint JS stuff
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
+    types: 
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
     paths:
       - '**.js'
       - '**.vue'

--- a/.github/workflows/test-and-lint-php.yml
+++ b/.github/workflows/test-and-lint-php.yml
@@ -2,7 +2,13 @@ name: Test & lint PHP stuff
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
+    types: 
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
     paths:
       - '**.php'
       - 'composer.json'


### PR DESCRIPTION
I updated GHA workflows. Without it, PRs converted from drafts (like #212) won't open any checks.