### PR TITLE
#240 - add statistics for remote work for employees with limit

### DIFF
--- a/app/Infrastructure/Http/Requests/VacationLimitRequest.php
+++ b/app/Infrastructure/Http/Requests/VacationLimitRequest.php
@@ -15,7 +15,7 @@ class VacationLimitRequest extends FormRequest
         return [
             "items" => ["required", "array"],
             "items.*.id" => ["required", "exists:vacation_limits,id"],
-            "items.*.days" => ["nullable", "integer", "min:0"],
+            "items.*.days" => ["nullable", "integer", "min:0", "max:100"],
         ];
     }
 

--- a/lang/pl/validation.php
+++ b/lang/pl/validation.php
@@ -161,6 +161,9 @@ return [
         "name" => [
             "unique" => "Taka nazwa już występuje.",
         ],
+        "items.*.days" => [
+            "max" => "Limit dni urlopu nie może być większy niż :max."
+        ],
     ],
     "attributes" => [
         "to" => "do",

--- a/lang/pl/validation.php
+++ b/lang/pl/validation.php
@@ -162,7 +162,7 @@ return [
             "unique" => "Taka nazwa już występuje.",
         ],
         "items.*.days" => [
-            "max" => "Limit dni urlopu nie może być większy niż :max."
+            "max" => "Limit dni urlopu nie może być większy niż :max.",
         ],
     ],
     "attributes" => [

--- a/resources/js/Shared/Widgets/VacationStats.vue
+++ b/resources/js/Shared/Widgets/VacationStats.vue
@@ -8,7 +8,7 @@ defineProps({
   <section>
     <div
       v-if="stats.hasLimit"
-      class="grid grid-cols-2 2xl:grid-cols-4 gap-2 h-full"
+      class="grid grid-cols-2 2xl:grid-cols-4 gap-2 mb-2 2xl:mb-4"
     >
       <div class="py-5 px-4 bg-white shadow-md sm:p-6">
         <dd class="mt-1 text-4xl font-semibold text-blumilk-500">
@@ -56,8 +56,7 @@ defineProps({
       </div>
     </div>
     <div
-      v-else
-      class="h-full grid grid-cols-2 gap-2 h-full"
+      class="grid grid-cols-2 gap-2"
     >
       <div class="py-5 px-4 bg-white shadow-md sm:p-6">
         <dt class="mt-1 text-4xl font-semibold text-gray-500">


### PR DESCRIPTION
This should close #240.

For now employees with vacation limit also can see statistics about remote work and other vacations:
![image](https://user-images.githubusercontent.com/56546832/194483656-c8b123cf-1eab-4cf2-b439-6ad749e56144.png)

Due to the fact that it was a minor change, I've added one more thing that I've noticed during testing - there was no maximum limit of vacation days. Now that limit is 100 days.