### PR TITLE
#248 - vacations indicator on vacation request view

### DIFF
--- a/app/Infrastructure/Http/Controllers/VacationRequestController.php
+++ b/app/Infrastructure/Http/Controllers/VacationRequestController.php
@@ -138,9 +138,9 @@ class VacationRequestController extends Controller
 
         $currentYearPeriod = $yearPeriodRetriever->selected();
 
-        $limit = $statsRetriever->getVacationDaysLimit($vacationRequest->user, $currentYearPeriod);
-        $used = $statsRetriever->getUsedVacationDays($vacationRequest->user, $currentYearPeriod);
-        $pending = $statsRetriever->getPendingVacationDays($vacationRequest->user, $currentYearPeriod);
+        $limit = $statsRetriever->getVacationDaysLimit($vacationRequest->user, $vacationRequest->yearPeriod);
+        $used = $statsRetriever->getUsedVacationDays($vacationRequest->user, $vacationRequest->yearPeriod);
+        $pending = $statsRetriever->getPendingVacationDays($vacationRequest->user, $vacationRequest->yearPeriod);
         $remaining = $limit - $used - $pending;
 
         return inertia("VacationRequest/Show", [

--- a/app/Infrastructure/Http/Controllers/VacationRequestController.php
+++ b/app/Infrastructure/Http/Controllers/VacationRequestController.php
@@ -23,6 +23,7 @@ use Toby\Domain\States\VacationRequest\AcceptedByAdministrative;
 use Toby\Domain\States\VacationRequest\AcceptedByTechnical;
 use Toby\Domain\States\VacationRequest\Cancelled;
 use Toby\Domain\States\VacationRequest\Rejected;
+use Toby\Domain\UserVacationStatsRetriever;
 use Toby\Domain\VacationRequestStatesRetriever;
 use Toby\Domain\VacationTypeConfigRetriever;
 use Toby\Eloquent\Helpers\YearPeriodRetriever;
@@ -130,10 +131,17 @@ class VacationRequestController extends Controller
     /**
      * @throws AuthorizationException
      */
-    public function show(Request $request, VacationRequest $vacationRequest): Response
+    public function show(Request $request, VacationRequest $vacationRequest, UserVacationStatsRetriever $statsRetriever, YearPeriodRetriever $yearPeriodRetriever): Response
     {
         $this->authorize("show", $vacationRequest);
         $user = $request->user();
+
+        $currentYearPeriod = $yearPeriodRetriever->selected();
+
+        $limit = $statsRetriever->getVacationDaysLimit($vacationRequest->user, $currentYearPeriod);
+        $used = $statsRetriever->getUsedVacationDays($vacationRequest->user, $currentYearPeriod);
+        $pending = $statsRetriever->getPendingVacationDays($vacationRequest->user, $currentYearPeriod);
+        $remaining = $limit - $used - $pending;
 
         return inertia("VacationRequest/Show", [
             "request" => new VacationRequestResource($vacationRequest),
@@ -147,6 +155,11 @@ class VacationRequestController extends Controller
                     && $user->can("reject", $vacationRequest),
                 "cancel" => $vacationRequest->state->canTransitionTo(Cancelled::class)
                     && $user->can("cancel", $vacationRequest),
+            ],
+            "stats" => [
+                "used" => $used,
+                "pending" => $pending,
+                "remaining" => $remaining,
             ],
         ]);
     }

--- a/app/Infrastructure/Http/Controllers/VacationRequestController.php
+++ b/app/Infrastructure/Http/Controllers/VacationRequestController.php
@@ -157,6 +157,7 @@ class VacationRequestController extends Controller
                     && $user->can("cancel", $vacationRequest),
             ],
             "stats" => [
+                "limit" => $limit,
                 "used" => $used,
                 "pending" => $pending,
                 "remaining" => $remaining,

--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -123,13 +123,16 @@ class DemoSeeder extends Seeder
         $year = 2021;
 
         YearPeriod::factory()
-            ->count(2)
+            ->count(3)
             ->sequence(
                 [
                     "year" => Carbon::createFromDate($year)->year,
                 ],
                 [
                     "year" => Carbon::createFromDate($year + 1)->year,
+                ],
+                [
+                    "year" => Carbon::createFromDate($year + 2)->year,
                 ],
             )
             ->afterCreating(function (YearPeriod $yearPeriod) use ($users): void {

--- a/resources/js/Pages/VacationRequest/Show.vue
+++ b/resources/js/Pages/VacationRequest/Show.vue
@@ -87,7 +87,7 @@ defineProps({
               </dd>
             </div>
             <div
-              v-if="request.isVacation && (can.acceptAsTechnical || can.acceptAsAdministrative)"
+              v-if="request.isVacation && (stats.limit > 0) && (can.acceptAsTechnical || can.acceptAsAdministrative)"
               class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-5 sm:px-6"
             >
               <dt class="flex items-center text-sm font-medium text-gray-500">

--- a/resources/js/Pages/VacationRequest/Show.vue
+++ b/resources/js/Pages/VacationRequest/Show.vue
@@ -87,7 +87,7 @@ defineProps({
               </dd>
             </div>
             <div
-              v-if="request.isVacation && (stats.limit > 0) && (can.acceptAsTechnical || can.acceptAsAdministrative)"
+              v-if="request.isVacation && (stats.limit > 0) && (can.acceptAsTechnical || can.acceptAsAdministrative || can.reject)"
               class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-5 sm:px-6"
             >
               <dt class="flex items-center text-sm font-medium text-gray-500">

--- a/resources/js/Pages/VacationRequest/Show.vue
+++ b/resources/js/Pages/VacationRequest/Show.vue
@@ -3,11 +3,13 @@ import { PaperClipIcon } from '@heroicons/vue/24/outline'
 import Activity from '@/Shared/Activity.vue'
 import Status from '@/Shared/Status.vue'
 import VacationType from '@/Shared/VacationType.vue'
+import VacationBar from '@/Shared/VacationBar.vue'
 
 defineProps({
   request: Object,
   can: Object,
   activities: Object,
+  stats: Object,
 })
 </script>
 
@@ -82,6 +84,17 @@ defineProps({
                 <span class="font-semibold">
                   [Liczba dni: {{ request.days.length }}]
                 </span>
+              </dd>
+            </div>
+            <div
+              v-if="request.isVacation && (can.acceptAsTechnical || can.acceptAsAdministrative)"
+              class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-5 sm:px-6"
+            >
+              <dt class="flex items-center text-sm font-medium text-gray-500">
+                Wykorzystanie urlopu
+              </dt>
+              <dd>
+                <VacationBar :stats="{ used: stats.used, pending: stats.pending, remaining: stats.remaining }" />
               </dd>
             </div>
             <div class="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-5 sm:px-6">


### PR DESCRIPTION
This should close #248.

When vacation request has state waiting for technical approval or waiting for administrative approval, limit for vacations is shown:

![image](https://user-images.githubusercontent.com/56546832/203745469-72fa2624-5186-40f1-92df-a0b6be052f95.png)
