### PR TITLE
#115 - Improve deployment workflows

### DIFF
--- a/.github/workflows/deploy-to-beta-manually.yml
+++ b/.github/workflows/deploy-to-beta-manually.yml
@@ -27,7 +27,7 @@ jobs:
           password: ${{ secrets.TOBY_VPS_PASSWORD }}
           script_stop: true
           script: |
-            cd /blumilk/beta/projects/toby
+            cd ${{ secrets.TOBY_VPS_BETA_APP_PATH }}
             git fetch
             git checkout --force "${{ env.BRANCH_NAME }}"
             git pull

--- a/.github/workflows/deploy-to-beta-manually.yml
+++ b/.github/workflows/deploy-to-beta-manually.yml
@@ -1,23 +1,23 @@
-name: Deploy to production
+name: Deploy to beta manually
 
 concurrency:
-  group: deploy-prod
-  cancel-in-progress: false
+  group: deploy-beta
+  cancel-in-progress: true
 
 on:
-  push:
-    tags:
-      - v*
+  workflow_dispatch:
 
 jobs:
+
   deploy:
-    environment: production
+    environment: beta
+    name: Deploy to beta
     runs-on: ubuntu-22.04
-    name: Deploy to production
+    env:
+      BRANCH_NAME: $GITHUB_REF_NAME
     steps:
-      - uses: appleboy/ssh-action@v0.1.5
-        env:
-          BRANCH_NAME: "main"
+      - name: run deployment script over ssh
+        uses: appleboy/ssh-action@v0.1.5
         with:
           timeout: 10s
           command_timeout: 10m
@@ -27,8 +27,8 @@ jobs:
           password: ${{ secrets.TOBY_VPS_PASSWORD }}
           script_stop: true
           script: |
-            cd /blumilk/production/toby
+            cd /blumilk/beta/projects/toby
             git fetch
             git checkout --force "${{ env.BRANCH_NAME }}"
             git pull
-            make prod-deploy
+            make beta-deploy

--- a/.github/workflows/deploy-to-beta.yml
+++ b/.github/workflows/deploy-to-beta.yml
@@ -83,7 +83,7 @@ jobs:
           password: ${{ secrets.TOBY_VPS_PASSWORD }}
           script_stop: true
           script: |
-            cd /blumilk/beta/projects/toby
+            cd ${{ secrets.TOBY_VPS_BETA_APP_PATH }}
             git fetch
             git checkout --force "${{ env.BRANCH_NAME }}"
             git pull

--- a/.github/workflows/deploy-to-beta.yml
+++ b/.github/workflows/deploy-to-beta.yml
@@ -9,8 +9,6 @@ on:
     types:
       - created
 
-  workflow_dispatch:
-
 jobs:
   pr_commented:
     name: Deploy triggered by PR comment trigger
@@ -18,7 +16,6 @@ jobs:
     # todo:   https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
 
     if: |
-      github.event_name != 'workflow_dispatch' &&
       contains('OWNER,MEMBER,COLLABORATOR', github.event.comment.author_association) &&
       github.event.issue.pull_request &&
       github.event.comment.body == '!deploy beta' 
@@ -63,9 +60,10 @@ jobs:
             })
 
   deploy:
+#    todo: deployments to beta environment are pointing to the default (main) branch always, due to `issue_comment` event uses workflow from the default branch.
     environment: beta
     needs: pr_commented
-    if: always() && (needs.pr_commented.result == 'success' || (github.event_name == 'workflow_dispatch' && needs.pr_commented.result == 'skipped'))
+    if: needs.pr_commented.result == 'success'
     name: Deploy to beta
     runs-on: ubuntu-22.04
     env:
@@ -86,10 +84,12 @@ jobs:
           script_stop: true
           script: |
             cd /blumilk/beta/projects/toby
-            BRANCH_NAME=${{ env.BRANCH_NAME }} make beta-deploy
+            git fetch
+            git checkout --force "${{ env.BRANCH_NAME }}"
+            git pull
+            make beta-deploy
 
       - name: comment PR that changes has been deployed to beta
-        if: github.event_name != 'workflow_dispatch'
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -27,7 +27,7 @@ jobs:
           password: ${{ secrets.TOBY_VPS_PASSWORD }}
           script_stop: true
           script: |
-            cd /blumilk/production/toby
+            cd ${{ secrets.TOBY_VPS_LIVE_APP_PATH }}
             git fetch
             git checkout --force "${{ env.BRANCH_NAME }}"
             git pull

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,6 @@ PROD_DOCKER_EXEC=docker compose --file ${DOCKER_COMPOSE_PROD_FILENAME} exec --wo
 
 .PHONY: beta-deploy
 beta-deploy:
-	git fetch && \
-	git checkout --force "${BRANCH_NAME}" && \
-	git pull && \
 	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose --file ${DOCKER_COMPOSE_BETA_FILENAME} build --pull && \
 	docker compose --file ${DOCKER_COMPOSE_BETA_FILENAME} up --detach && \
 	${BETA_DOCKER_EXEC} toby-beta-php bash post-deploy-actions.sh && \
@@ -23,9 +20,6 @@ beta-reload-config:
 
 .PHONY: prod-deploy
 prod-deploy:
-	git fetch && \
-	git checkout --force "${BRANCH_NAME}" && \
-	git pull && \
 	COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker compose --file ${DOCKER_COMPOSE_PROD_FILENAME} build --pull && \
 	docker compose --file ${DOCKER_COMPOSE_PROD_FILENAME} up --detach && \
 	${PROD_DOCKER_EXEC} toby-prod-php bash post-deploy-actions.sh && \


### PR DESCRIPTION
This PR contains fixups for deploy workflows:
1. Moved  git commands from Makefile to workflow, due to bug that Makefile is in locked state between deploys (Makefile is run, then changes are pulled, so changes in Makefile between deploys had no effects)
2. Splitted manual deploy to another workflow to simplify logic