### PR TITLE
- fix docker rmi command if empty arguments

### DIFF
--- a/.github/workflows/deploy-to-beta-manually.yml
+++ b/.github/workflows/deploy-to-beta-manually.yml
@@ -64,4 +64,4 @@ jobs:
             git pull
             git merge --no-commit --no-ff origin/main
             make beta-deploy
-            docker images --filter dangling=true | grep "ghcr.io/blumilksoftware/toby" | awk '{print $3}'| xargs docker rmi
+            docker images --filter dangling=true | grep "ghcr.io/blumilksoftware/toby" | awk '{print $3}'| xargs --no-run-if-empty docker rmi

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -57,4 +57,4 @@ jobs:
             git checkout --force "${{ env.BRANCH_NAME }}"
             git pull
             make prod-deploy
-            docker images --filter dangling=true | grep "ghcr.io/blumilksoftware/toby" | awk '{print $3}'| xargs docker rmi
+            docker images --filter dangling=true | grep "ghcr.io/blumilksoftware/toby" | awk '{print $3}'| xargs --no-run-if-empty docker rmi


### PR DESCRIPTION
This fixes `"docker rmi" requires at least 1 argument.` output if there are no dangling docker images.