### PR TITLE
- support php artisan commands on beta via workflow

### DIFF
--- a/.github/workflows/deploy-to-beta-manually.yml
+++ b/.github/workflows/deploy-to-beta-manually.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: sync with main branch
         run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
           git merge --no-commit --no-ff origin/main
 
       - name: set up Docker Buildx

--- a/.github/workflows/deploy-to-beta-manually.yml
+++ b/.github/workflows/deploy-to-beta-manually.yml
@@ -61,6 +61,8 @@ jobs:
           script_stop: true
           script: |
             cd ${{ secrets.TOBY_VPS_BETA_APP_PATH }}
+            git config user.name "GitHub Actions Bot"
+            git config user.email "<>"
             git fetch
             git checkout --force "${{ env.BRANCH_NAME }}"
             git pull

--- a/.github/workflows/run-command-on-beta.yml
+++ b/.github/workflows/run-command-on-beta.yml
@@ -5,6 +5,7 @@ on:
     inputs:
       artisan_arguments:
         description: "PHP Artisan command arguments (php artisan <args>)"
+        type: string
         required: true
 
 jobs:

--- a/.github/workflows/run-command-on-beta.yml
+++ b/.github/workflows/run-command-on-beta.yml
@@ -1,0 +1,29 @@
+name: Run PHP Artisan command on beta
+
+on:
+  workflow_dispatch:
+    inputs:
+      artisan_arguments:
+        description: "PHP Artisan command arguments (php artisan <args>)"
+        required: true
+
+jobs:
+
+  run-command:
+    name: Run command via ssh
+    runs-on: ubuntu-22.04
+    steps:
+      - name: run php artisan command
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          timeout: 10s
+          command_timeout: 10m
+          host: ${{ secrets.VPS_OVH_BF7EC892_HOST }}
+          port: ${{ secrets.VPS_OVH_BF7EC892_PORT }}
+          username: ${{ secrets.VPS_OVH_BF7EC892_USERNAME }}
+          key: ${{ secrets.VPS_OVH_BF7EC892_SSH_PRIVATE_KEY }}
+          passphrase: ${{ secrets.VPS_OVH_BF7EC892_SSH_PRIVATE_KEY_PASSPHRASE }}
+          script_stop: true
+          script: |
+            cd ${{ secrets.TOBY_VPS_BETA_APP_PATH }}
+            make beta-artisan ARTISAN_ARGS="${{ inputs.artisan_arguments }}"

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ PROD_DOCKER_EXEC = docker compose --file ${DOCKER_COMPOSE_PROD_FILENAME} exec --
 export COMPOSE_DOCKER_CLI_BUILD = 1
 export DOCKER_BUILDKIT = 1
 
+beta-artisan:
+	echo "Running: php artisan ${ARTISAN_ARGS}" && \
+	docker compose --file ${DOCKER_COMPOSE_BETA_FILENAME} exec toby-beta-app php artisan ${ARTISAN_ARGS}
+
 beta-deploy: create-deployment-file
 	docker compose --file ${DOCKER_COMPOSE_BETA_FILENAME} up --force-recreate --detach && \
 	echo "App post deploy actions" && \
@@ -35,4 +39,4 @@ create-deployment-file:
 	DEPLOY_VERSION='${DEPLOYMENT_PROJECT_VERSION}'\
 	" > .deployment
 
-.PHONY: beta-deploy beta-reload-config prod-deploy prod-reload-config create-deployment-file
+.PHONY: beta-deploy beta-reload-config prod-deploy prod-reload-config create-deployment-file beta-artisan


### PR DESCRIPTION
This PR adds support for running php artisan non-interactive commands on beta.

For the input, only args should be provided, without `php artisan`