### PR TITLE
#378 - clickable events in calendar

### DIFF
--- a/app/Domain/Actions/Slack/UpdateDailySummaryAction.php
+++ b/app/Domain/Actions/Slack/UpdateDailySummaryAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Toby\Domain\Actions\Slack;
 
 use Toby\Domain\DailySummaryRetriever;
+use Toby\Domain\VacationRequestStatesRetriever;
 use Toby\Eloquent\Models\DailySummary;
 use Toby\Eloquent\Models\User;
 use Toby\Eloquent\Models\VacationRequest;
@@ -22,12 +23,14 @@ class UpdateDailySummaryAction
                 fn(VacationRequest $request) => [
                     "id" => $request->user->id,
                     "name" => $request->user->profile->fullName,
+                    "pending" => $request->state->equals(...VacationRequestStatesRetriever::pendingStates()),
                 ],
             )->toArray(),
             "remotes" => $this->dailySummaryRetriever->getRemoteDays($dailySummary->day)->map(
                 fn(VacationRequest $request) => [
                     "id" => $request->user->id,
                     "name" => $request->user->profile->fullName,
+                    "pending" => $request->state->equals(...VacationRequestStatesRetriever::pendingStates()),
                 ],
             )->toArray(),
             "birthdays" => $this->dailySummaryRetriever->getUpcomingBirthdays()->map(fn(User $user) => [

--- a/app/Domain/Actions/VacationRequest/WaitForAdminApprovalAction.php
+++ b/app/Domain/Actions/VacationRequest/WaitForAdminApprovalAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Toby\Domain\Actions\VacationRequest;
 
 use Spatie\Permission\Models\Permission;
+use Toby\Domain\Events\VacationRequestChanged;
 use Toby\Domain\Notifications\VacationRequestWaitsForApprovalNotification;
 use Toby\Domain\VacationRequestStateManager;
 use Toby\Domain\VacationTypeConfigRetriever;
@@ -26,6 +27,8 @@ class WaitForAdminApprovalAction
         if ($this->configRetriever->isVacation($vacationRequest->type)) {
             $this->notifyAuthorizedUsers($vacationRequest);
         }
+
+        event(new VacationRequestChanged($vacationRequest));
     }
 
     protected function notifyAuthorizedUsers(VacationRequest $vacationRequest): void

--- a/app/Domain/Actions/VacationRequest/WaitForTechApprovalAction.php
+++ b/app/Domain/Actions/VacationRequest/WaitForTechApprovalAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Toby\Domain\Actions\VacationRequest;
 
 use Spatie\Permission\Models\Permission;
+use Toby\Domain\Events\VacationRequestChanged;
 use Toby\Domain\Notifications\VacationRequestWaitsForApprovalNotification;
 use Toby\Domain\VacationRequestStateManager;
 use Toby\Domain\VacationTypeConfigRetriever;
@@ -26,6 +27,8 @@ class WaitForTechApprovalAction
         if ($this->configRetriever->isVacation($vacationRequest->type)) {
             $this->notifyTechApprovers($vacationRequest);
         }
+
+        event(new VacationRequestChanged($vacationRequest));
     }
 
     protected function notifyTechApprovers(VacationRequest $vacationRequest): void

--- a/app/Domain/DailySummaryRetriever.php
+++ b/app/Domain/DailySummaryRetriever.php
@@ -26,7 +26,7 @@ class DailySummaryRetriever
             ->with(["user"])
             ->whereDate("from", "<=", $date)
             ->whereDate("to", ">=", $date)
-            ->states(VacationRequestStatesRetriever::successStates())
+            ->states(VacationRequestStatesRetriever::notFailedStates())
             ->whereIn(
                 "type",
                 VacationType::all()->filter(fn(VacationType $type): bool => $this->configRetriever->isVacation($type)),
@@ -44,7 +44,7 @@ class DailySummaryRetriever
             ->with(["user"])
             ->whereDate("from", "<=", $date)
             ->whereDate("to", ">=", $date)
-            ->states(VacationRequestStatesRetriever::successStates())
+            ->states(VacationRequestStatesRetriever::notFailedStates())
             ->whereIn(
                 "type",
                 VacationType::all()->filter(fn(VacationType $type): bool => !$this->configRetriever->isVacation($type)),
@@ -61,7 +61,7 @@ class DailySummaryRetriever
         return VacationRequest::query()
             ->with(["user"])
             ->whereDate("from", ">", $date)
-            ->states(VacationRequestStatesRetriever::successStates())
+            ->states(VacationRequestStatesRetriever::notFailedStates())
             ->whereIn(
                 "type",
                 VacationType::all()->filter(fn(VacationType $type): bool => $this->configRetriever->isVacation($type)),
@@ -79,7 +79,7 @@ class DailySummaryRetriever
         return VacationRequest::query()
             ->with(["user"])
             ->whereDate("from", ">", $date)
-            ->states(VacationRequestStatesRetriever::successStates())
+            ->states(VacationRequestStatesRetriever::notFailedStates())
             ->whereIn(
                 "type",
                 VacationType::all()->filter(fn(VacationType $type): bool => !$this->configRetriever->isVacation($type)),

--- a/app/Domain/DashboardAggregator.php
+++ b/app/Domain/DashboardAggregator.php
@@ -11,8 +11,8 @@ use Toby\Eloquent\Models\User;
 use Toby\Eloquent\Models\Vacation;
 use Toby\Eloquent\Models\YearPeriod;
 use Toby\Infrastructure\Http\Resources\BirthdayResource;
+use Toby\Infrastructure\Http\Resources\DashboardVacationRequestResource;
 use Toby\Infrastructure\Http\Resources\HolidayResource;
-use Toby\Infrastructure\Http\Resources\SimpleVacationRequestResource;
 use Toby\Infrastructure\Http\Resources\UserBenefitsResource;
 use Toby\Infrastructure\Http\Resources\VacationRequestResource;
 
@@ -55,7 +55,7 @@ class DashboardAggregator
             ->get()
             ->mapWithKeys(
                 fn(Vacation $vacation): array => [
-                    $vacation->date->toDateString() => new SimpleVacationRequestResource($vacation->vacationRequest),
+                    $vacation->date->toDateString() => new DashboardVacationRequestResource($vacation->vacationRequest),
                 ],
             );
 
@@ -67,7 +67,7 @@ class DashboardAggregator
             ->get()
             ->mapWithKeys(
                 fn(Vacation $vacation): array => [
-                    $vacation->date->toDateString() => new SimpleVacationRequestResource($vacation->vacationRequest),
+                    $vacation->date->toDateString() => new DashboardVacationRequestResource($vacation->vacationRequest),
                 ],
             );
 
@@ -109,8 +109,8 @@ class DashboardAggregator
         $remoteDays = $this->dailySummaryRetriever->getRemoteDays($today);
 
         return [
-            "absences" => VacationRequestResource::collection($absences),
-            "remoteDays" => VacationRequestResource::collection($remoteDays),
+            "absences" => DashboardVacationRequestResource::collection($absences),
+            "remoteDays" => DashboardVacationRequestResource::collection($remoteDays),
         ];
     }
 
@@ -129,8 +129,8 @@ class DashboardAggregator
             ->get();
 
         return [
-            "absences" => VacationRequestResource::collection($upcomingAbsences),
-            "remoteDays" => VacationRequestResource::collection($upcomingRemoteDays),
+            "absences" => DashboardVacationRequestResource::collection($upcomingAbsences),
+            "remoteDays" => DashboardVacationRequestResource::collection($upcomingRemoteDays),
             "birthdays" => BirthdayResource::collection($upcomingBirthdays),
             "holidays" => HolidayResource::collection($upcomingHolidays),
         ];

--- a/app/Domain/VacationRequestStatesRetriever.php
+++ b/app/Domain/VacationRequestStatesRetriever.php
@@ -41,6 +41,11 @@ class VacationRequestStatesRetriever
         ];
     }
 
+    public static function notFailedStates(): array
+    {
+        return array_merge(static::successStates(), static::pendingStates());
+    }
+
     public static function waitingForUserActionStates(User $user): array
     {
         return match ($user->role) {

--- a/app/Infrastructure/Http/Resources/DashboardVacationRequestResource.php
+++ b/app/Infrastructure/Http/Resources/DashboardVacationRequestResource.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Toby\Infrastructure\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Toby\Domain\VacationRequestStatesRetriever;
+use Toby\Domain\VacationTypeConfigRetriever;
+
+class DashboardVacationRequestResource extends JsonResource
+{
+    public static $wrap = null;
+    protected VacationTypeConfigRetriever $configRetriever;
+
+    public function __construct($resource)
+    {
+        parent::__construct($resource);
+
+        $this->configRetriever = app(VacationTypeConfigRetriever::class);
+    }
+
+    public function toArray($request): array
+    {
+        $user = $request->user();
+
+        return [
+            "id" => $this->id,
+            "user" => new SimpleUserResource($this->user),
+            "type" => $this->type,
+            "state" => $this->state,
+            "from" => $this->from->toDisplayString(),
+            "to" => $this->to->toDisplayString(),
+            "displayDate" => $this->getDate($this->from->toDisplayString(), $this->to->toDisplayString()),
+            "days" => VacationResource::collection($this->vacations),
+            "pending" => $this->state->equals(...VacationRequestStatesRetriever::pendingStates()),
+        ];
+    }
+
+    private function getDate(string $from, string $to): string
+    {
+        return ($from !== $to)
+            ? "{$from} - {$to}"
+            : $from;
+    }
+}

--- a/app/Infrastructure/Http/Resources/SimpleVacationRequestResource.php
+++ b/app/Infrastructure/Http/Resources/SimpleVacationRequestResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Toby\Infrastructure\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use Toby\Domain\VacationRequestStatesRetriever;
 
 class SimpleVacationRequestResource extends JsonResource
 {
@@ -17,6 +18,7 @@ class SimpleVacationRequestResource extends JsonResource
             "name" => $this->name,
             "type" => $this->type,
             "state" => $this->state,
+            "pending" => $this->state->equals(...VacationRequestStatesRetriever::pendingStates()),
             "from" => $this->from->toDisplayString(),
             "to" => $this->to->toDisplayString(),
             "days" => $this->vacations->count(),

--- a/config/vacation_types.php
+++ b/config/vacation_types.php
@@ -61,13 +61,14 @@ return [
     ],
     VacationType::Sick->value => [
         VacationTypeConfigRetriever::KEY_TECHNICAL_APPROVAL => false,
-        VacationTypeConfigRetriever::KEY_ADMINISTRATIVE_APPROVAL => false,
+        VacationTypeConfigRetriever::KEY_ADMINISTRATIVE_APPROVAL => true,
         VacationTypeConfigRetriever::KEY_BILLABLE => true,
         VacationTypeConfigRetriever::KEY_HAS_LIMIT => false,
         VacationTypeConfigRetriever::KEY_AVAILABLE_FOR => [
             EmploymentForm::EmploymentContract,
         ],
         VacationTypeConfigRetriever::KEY_REQUEST_ALLOWED_FOR => [
+            Role::Employee,
             Role::Administrator,
             Role::AdministrativeApprover,
             Role::TechnicalApprover,

--- a/database/seeders/DemoSeeder.php
+++ b/database/seeders/DemoSeeder.php
@@ -125,19 +125,19 @@ class DemoSeeder extends Seeder
 
         $users = User::all();
 
-        $year = 2021;
+        $year = Carbon::now()->year;
 
         YearPeriod::factory()
             ->count(3)
             ->sequence(
                 [
+                    "year" => Carbon::createFromDate($year - 1)->year,
+                ],
+                [
                     "year" => Carbon::createFromDate($year)->year,
                 ],
                 [
                     "year" => Carbon::createFromDate($year + 1)->year,
-                ],
-                [
-                    "year" => Carbon::createFromDate($year + 2)->year,
                 ],
             )
             ->afterCreating(function (YearPeriod $yearPeriod) use ($users): void {
@@ -162,7 +162,7 @@ class DemoSeeder extends Seeder
             })
             ->create();
 
-        $currentYearPeriod = YearPeriod::query()->where("year", 2022)->first();
+        $currentYearPeriod = YearPeriod::query()->where("year", $year)->first();
 
         /** @var VacationRequest $vacationRequestApproved */
         $vacationRequestApproved = VacationRequest::factory([

--- a/resources/js/Pages/AnnualSummary.vue
+++ b/resources/js/Pages/AnnualSummary.vue
@@ -131,7 +131,10 @@ function getVacationInfo(day) {
                   </button>
                 </div>
                 <template #content>
-                  <VacationPopup :vacation="getVacationInfo(day)" />
+                  <VacationPopup
+                    :vacation="getVacationInfo(day)"
+                    :see-vacation-details="true"
+                  />
                 </template>
               </Popper>
               <Popper

--- a/resources/js/Pages/Calendar.vue
+++ b/resources/js/Pages/Calendar.vue
@@ -3,7 +3,6 @@ import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/vue/24/solid'
 import { computed, ref } from 'vue'
 import { useMonthInfo } from '@/Composables/monthInfo.js'
 import VacationTypeCalendarIcon from '@/Shared/VacationTypeCalendarIcon.vue'
-import VacationPopup from '@/Shared/VacationPopup.vue'
 import CalendarDay from '@/Shared/CalendarDay.vue'
 
 const props = defineProps({

--- a/resources/js/Pages/Calendar.vue
+++ b/resources/js/Pages/Calendar.vue
@@ -3,6 +3,8 @@ import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/vue/24/solid'
 import { computed, ref } from 'vue'
 import { useMonthInfo } from '@/Composables/monthInfo.js'
 import VacationTypeCalendarIcon from '@/Shared/VacationTypeCalendarIcon.vue'
+import VacationPopup from '@/Shared/VacationPopup.vue'
+import CalendarDay from '@/Shared/CalendarDay.vue'
 
 const props = defineProps({
   users: Object,
@@ -39,6 +41,10 @@ function unsetActiveDay() {
 
 function linkParameters(user, day) {
   return props.auth.can.createRequestsOnBehalfOfEmployee ? { user: user.id, from_date: day.date } : { from_date: day.date }
+}
+
+function linkVacationRequest(user){
+  return props.auth.user.id === user.id || props.auth.can.manageRequestsAsTechnicalApprover || props.auth.can.manageRequestsAsAdministrativeApprover
 }
 </script>
 
@@ -149,19 +155,13 @@ function linkParameters(user, day) {
               @mouseleave="unsetActiveDay"
             >
               <div
-                v-if="day.pendingVacations.includes(user.id) && (auth.user.id === user.id || auth.can.manageRequestsAsAdministrativeApprover || auth.can.manageRequestsAsTechnicalApprover)"
+                v-if="user.id in day.vacations"
                 class="flex justify-center items-center"
               >
-                <VacationTypeCalendarIcon
-                  :type="day.vacationPendingTypes[user.id]"
-                  :opacity="true"
+                <CalendarDay
+                  :vacation="day.vacations[user.id]"
+                  :see-vacation-details="linkVacationRequest(user)"
                 />
-              </div>
-              <div
-                v-else-if="day.vacations.includes(user.id)"
-                class="flex justify-center items-center"
-              >
-                <VacationTypeCalendarIcon :type="day.vacationTypes[user.id]" />
               </div>
               <template
                 v-else-if="isActiveDay(user.id + '+' + day.date) && !day.isWeekend && !day.isHoliday && (auth.user.id === user.id || auth.can.createRequestsOnBehalfOfEmployee)"

--- a/resources/js/Shared/CalendarDay.vue
+++ b/resources/js/Shared/CalendarDay.vue
@@ -1,0 +1,32 @@
+<script setup>
+import { computed } from 'vue'
+import useVacationTypeInfo from '@/Composables/vacationTypeInfo.js'
+import VacationPopup from '@/Shared/VacationPopup.vue'
+import VacationTypeCalendarIcon from '@/Shared/VacationTypeCalendarIcon.vue'
+import Popper from 'vue3-popper'
+
+const props = defineProps({
+  vacation: Object,
+  seeVacationDetails: Boolean,
+})
+
+</script>
+
+<template>
+  <Popper
+    open-delay="200"
+    hover
+    offset-distance="0"
+  >
+    <VacationTypeCalendarIcon
+      :type="props.vacation.type"
+      :opacity="props.vacation.pending"
+    />
+    <template #content>
+      <VacationPopup
+        :vacation="props.vacation"
+        :see-vacation-details="props.seeVacationDetails"
+      />
+    </template>
+  </Popper>
+</template>

--- a/resources/js/Shared/CalendarDay.vue
+++ b/resources/js/Shared/CalendarDay.vue
@@ -1,6 +1,4 @@
 <script setup>
-import { computed } from 'vue'
-import useVacationTypeInfo from '@/Composables/vacationTypeInfo.js'
 import VacationPopup from '@/Shared/VacationPopup.vue'
 import VacationTypeCalendarIcon from '@/Shared/VacationTypeCalendarIcon.vue'
 import Popper from 'vue3-popper'

--- a/resources/js/Shared/Layout/AppLayout.vue
+++ b/resources/js/Shared/Layout/AppLayout.vue
@@ -36,7 +36,7 @@ watch(() => props.flash, flash => {
       :years="years"
       :vacation-requests-count="vacationRequestsCount"
     />
-    <main class="flex flex-col flex-1 py-8 lg:ml-64">
+    <main class="flex flex-col flex-1 py-8 lg:ml-60">
       <div class="lg:px-4">
         <slot />
       </div>

--- a/resources/js/Shared/MainMenu.vue
+++ b/resources/js/Shared/MainMenu.vue
@@ -296,7 +296,7 @@ const miscNavigation = computed(() => [
     </Dialog>
   </TransitionRoot>
 
-  <div class="hidden lg:flex lg:fixed lg:inset-y-0 lg:flex-col lg:w-64">
+  <div class="hidden lg:flex lg:fixed lg:inset-y-0 lg:flex-col lg:w-60">
     <div class="flex overflow-y-auto flex-col grow pt-5 pb-4 bg-blumilk-700">
       <div class="flex shrink-0 items-center px-4">
         <InertiaLink href="/">
@@ -364,7 +364,7 @@ const miscNavigation = computed(() => [
     </div>
   </div>
 
-  <div class="flex flex-col flex-1 lg:pl-64">
+  <div class="flex flex-col flex-1 lg:pl-60">
     <div class="flex relative z-10 shrink-0 h-16 bg-white border-b border-gray-200">
       <button
         type="button"

--- a/resources/js/Shared/VacationPopup.vue
+++ b/resources/js/Shared/VacationPopup.vue
@@ -4,15 +4,18 @@ import Status from '@/Shared/Status.vue'
 
 defineProps({
   vacation: Object,
+  seeVacationDetails: Boolean,
 })
 
 </script>
 
-
 <template>
   <div class="py-2 px-6 text-left text-gray-900 whitespace-nowrap bg-white rounded-lg border border-gray-400">
     <dl class="divide-y divide-gray-200">
-      <div class="py-2 space-y-1">
+      <div
+        v-if="seeVacationDetails"
+        class="py-2 space-y-1"
+      >
         <dt class="text-sm font-medium text-gray-500">
           Nr wniosku
         </dt>
@@ -23,6 +26,17 @@ defineProps({
           >
             {{ vacation.name }}
           </InertiaLink>
+        </dd>
+      </div>
+      <div
+        v-else
+        class="py-2 space-y-1"
+      >
+        <dt class="text-sm font-medium text-gray-500">
+          Nr wniosku
+        </dt>
+        <dd class="text-sm text-gray-900 font-semibold">
+          {{ vacation.name }}
         </dd>
       </div>
       <div class="py-2 space-y-1">

--- a/resources/js/Shared/VacationTypeCalendarIcon.vue
+++ b/resources/js/Shared/VacationTypeCalendarIcon.vue
@@ -17,18 +17,11 @@ const typeInfo = computed(() => findType(props.type))
 </script>
 
 <template>
-  <Popper hover>
-    <div class="flex items-center">
-      <div>
-        <span :class="[ opacity ? 'opacity-30': '' ,typeInfo.color, 'flex items-center justify-center']">
-          <component :is="typeInfo.icon" />
-        </span>
-      </div>
+  <div class="flex items-center">
+    <div>
+      <span :class="[ opacity ? 'opacity-30': '' ,typeInfo.color, 'flex items-center justify-center']">
+        <component :is="typeInfo.icon" />
+      </span>
     </div>
-    <template #content>
-      <div class="py-2 px-4 text-xs text-gray-900 bg-white rounded-lg border border-gray-400 ">
-        {{ typeInfo.text }}
-      </div>
-    </template>
-  </Popper>
+  </div>
 </template>

--- a/resources/js/Shared/VacationTypeCalendarIcon.vue
+++ b/resources/js/Shared/VacationTypeCalendarIcon.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { computed } from 'vue'
 import useVacationTypeInfo from '@/Composables/vacationTypeInfo.js'
-import Popper from 'vue3-popper'
 
 const props = defineProps({
   type: String,

--- a/resources/js/Shared/Widgets/AbsenceList.vue
+++ b/resources/js/Shared/Widgets/AbsenceList.vue
@@ -70,7 +70,7 @@ defineProps({
                   {{ day.user.email }}
                 </p>
                 <p class="text-sm text-gray-500">
-                  {{ day.displayDate }} <span v-if="day.pending">(Oczekujące)</span>
+                  {{ day.displayDate }} <span v-if="day.pending">(oczekujące)</span>
                 </p>
               </div>
             </li>
@@ -109,7 +109,7 @@ defineProps({
                   {{ day.user.email }}
                 </p>
                 <p class="text-sm text-gray-500">
-                  {{ day.displayDate }} <span v-if="day.pending">(Oczekujące)</span>
+                  {{ day.displayDate }} <span v-if="day.pending">(oczekujące)</span>
                 </p>
               </div>
             </li>

--- a/resources/js/Shared/Widgets/AbsenceList.vue
+++ b/resources/js/Shared/Widgets/AbsenceList.vue
@@ -55,7 +55,7 @@ defineProps({
           >
             <li
               v-for="day in absences"
-              :key="day.user.id"
+              :key="day.id"
               class="flex py-4"
             >
               <img
@@ -70,7 +70,7 @@ defineProps({
                   {{ day.user.email }}
                 </p>
                 <p class="text-sm text-gray-500">
-                  {{ day.displayDate }}
+                  {{ day.displayDate }} <span v-if="day.pending">(Oczekujące)</span>
                 </p>
               </div>
             </li>
@@ -109,7 +109,7 @@ defineProps({
                   {{ day.user.email }}
                 </p>
                 <p class="text-sm text-gray-500">
-                  {{ day.displayDate }}
+                  {{ day.displayDate }} <span v-if="day.pending">(Oczekujące)</span>
                 </p>
               </div>
             </li>

--- a/resources/js/Shared/Widgets/Calendar/DayComponent.vue
+++ b/resources/js/Shared/Widgets/Calendar/DayComponent.vue
@@ -87,7 +87,10 @@ function onMouseleave() {
         </div>
       </div>
       <template #content>
-        <VacationPopup :vacation="day.getVacationInfo" />
+        <VacationPopup
+          :vacation="day.getVacationInfo"
+          :see-vacation-details="true"
+        />
       </template>
     </Popper>
     <div

--- a/resources/js/Shared/Widgets/RemoteWorkList.vue
+++ b/resources/js/Shared/Widgets/RemoteWorkList.vue
@@ -70,7 +70,7 @@ defineProps({
                   {{ day.user.email }}
                 </p>
                 <p class="text-sm text-gray-500">
-                  {{ day.displayDate }}
+                  {{ day.displayDate }} <span v-if="day.pending">(Oczekujące)</span>
                 </p>
               </div>
             </li>
@@ -112,7 +112,7 @@ defineProps({
                   {{ day.user.email }}
                 </p>
                 <p class="text-sm text-gray-500">
-                  {{ day.displayDate }}
+                  {{ day.displayDate }} <span v-if="day.pending">(Oczekujące)</span>
                 </p>
               </div>
             </li>

--- a/resources/js/Shared/Widgets/RemoteWorkList.vue
+++ b/resources/js/Shared/Widgets/RemoteWorkList.vue
@@ -70,7 +70,7 @@ defineProps({
                   {{ day.user.email }}
                 </p>
                 <p class="text-sm text-gray-500">
-                  {{ day.displayDate }} <span v-if="day.pending">(Oczekujące)</span>
+                  {{ day.displayDate }} <span v-if="day.pending">(oczekujące)</span>
                 </p>
               </div>
             </li>
@@ -112,7 +112,7 @@ defineProps({
                   {{ day.user.email }}
                 </p>
                 <p class="text-sm text-gray-500">
-                  {{ day.displayDate }} <span v-if="day.pending">(Oczekujące)</span>
+                  {{ day.displayDate }} <span v-if="day.pending">(oczekujące)</span>
                 </p>
               </div>
             </li>

--- a/tests/Feature/VacationRequestTest.php
+++ b/tests/Feature/VacationRequestTest.php
@@ -728,6 +728,7 @@ class VacationRequestTest extends FeatureTestCase
                 ["label" => "Urlop bezpłatny", "value" => "unpaid_vacation"],
                 ["label" => "Wolontariat", "value" => "volunteering_vacation"],
                 ["label" => "Odbiór za święto", "value" => "time_in_lieu"],
+                ["label" => "Zwolnienie lekarskie", "value" => "sick_vacation"],
                 ["label" => "Nieobecność", "value" => "absence"],
                 ["label" => "Praca zdalna", "value" => "remote_work"],
             ]);


### PR DESCRIPTION
For now, when user goes to page "Calendar" he can hover mouse on icon and after that he see details about request. What's more, if he has permission, he can click on request number and he will be redirected to the request. 

![image](https://github.com/blumilksoftware/toby/assets/56546832/83e14789-d09d-4d70-a7eb-2cd1de280906)

If he doesn't have permission, the request number is not clickable, but he can see request details.

![image](https://github.com/blumilksoftware/toby/assets/56546832/d866bffe-9be9-4f84-bc76-9b20810089b6)


What's more, it this pr is resolved task connected with drafts. For now employee can create request about sick vacation - everybody will see in the calendar (icon will be faded a bit) and on the dashboard that the employee created the request and he is absent, but the request waits for approval. 

Moreover - all pending request are seen by all employees, but it's not the problem I think.

On the dashboard is placed information about that the request has state "pending"

![image](https://github.com/blumilksoftware/toby/assets/56546832/5f67b63b-3625-4bdd-bc2b-1f13c6145146)

On Slack (I mean daily summary) also individuals with requests in "pending" status are also included. However, there is no information indicating whether a request is pending or not. At this point, we wanted to simplify this. Moreover, if someone is highly interested in whether the request of a particular individual has been accepted or is pending, they can access the application in the system. Additionally, in the daily summary (in my opinion), employees are more concerned about who is absent rather than whether their request is accepted or pending.

This should close #378.
This should close #380.