### PR TITLE
- use secure session cookie on beta and prod environments

### DIFF
--- a/environment/prod/deployment/beta/.env.beta
+++ b/environment/prod/deployment/beta/.env.beta
@@ -28,3 +28,5 @@ XDG_CONFIG_HOME=/tmp
 GITHUB_REPO_URL=https://github.com/blumilksoftware/toby/
 
 SENTRY_TRACES_SAMPLE_RATE=0.1
+
+SESSION_SECURE_COOKIE=true

--- a/environment/prod/deployment/prod/.env.prod
+++ b/environment/prod/deployment/prod/.env.prod
@@ -30,3 +30,5 @@ SLACK_ENABLED=true
 GITHUB_REPO_URL=https://github.com/blumilksoftware/toby/
 
 SENTRY_TRACES_SAMPLE_RATE=0.1
+
+SESSION_SECURE_COOKIE=true


### PR DESCRIPTION
This PR improves security of session cookie.

---

Scan: https://observatory.mozilla.org/
```
[Cookies](https://infosec.mozilla.org/guidelines/web_security#cookies)		-40	Session cookie set without using the Secure flag or set over HTTP
```

![image](https://github.com/blumilksoftware/toby/assets/22484267/f5fe77b0-81b0-4d0b-8524-7326ccff1926)
