### PR TITLE
- switch beta to Blumilk's docker registry

### DIFF
--- a/.github/workflows/deploy-to-beta-manually.yml
+++ b/.github/workflows/deploy-to-beta-manually.yml
@@ -14,7 +14,9 @@ jobs:
     name: Deploy to beta
     runs-on: ubuntu-22.04
     env:
-      REPO_NAME: toby
+      DOCKER_REGISTRY: registry.blumilk.pl
+      DOCKER_REGISTRY_USER_NAME: robot@blumilkbot-harbor
+      DOCKER_REGISTRY_PROJECT_NAME: ${{ github.event.repository.name }}
     steps:
       - name: set branch name
         run: echo "BRANCH_NAME=$GITHUB_REF_NAME" >> $GITHUB_ENV
@@ -40,15 +42,18 @@ jobs:
       - name: login to GitHub Container Registry
         uses: docker/login-action@v3.1.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
+          registry: ${{ env.DOCKER_REGISTRY }}
+          username: ${{ env.DOCKER_REGISTRY_USER_NAME }}
+          password: ${{ secrets.BLUMILKBOT_HARBOR_TOKEN }}
+
+      - name: set docker image name
+        run: echo "DOCKER_IMAGE_NAME=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REGISTRY_PROJECT_NAME }}/${{ env.DOCKER_REGISTRY_PROJECT_NAME }}" >> $GITHUB_ENV
 
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5.5.1
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ env.REPO_NAME }}
+          images: ${{ env.DOCKER_IMAGE_NAME }}
           tags: type=raw,value=beta
           context: git
 
@@ -59,10 +64,10 @@ jobs:
           file: ./environment/prod/app/Dockerfile
           build-args: DEPLOYMENT_PROJECT_VERSION_ARG=${{ env.DEPLOYMENT_PROJECT_VERSION }}
           labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/${{ env.REPO_NAME }}:beta
-          cache-from: type=gha, ref=ghcr.io/${{ github.repository_owner }}/${{ env.REPO_NAME }}-beta-build-cache
-          cache-to: type=gha, ref=ghcr.io/${{ github.repository_owner }}/${{ env.REPO_NAME }}-beta-build-cache, mode=max
+          cache-from: type=gha, ref=${{ env.DOCKER_IMAGE_NAME }}-beta-build-cache
+          cache-to: type=gha, ref=${{ env.DOCKER_IMAGE_NAME }}-beta-build-cache, mode=max
 
       - name: copy files via ssh
         uses: appleboy/scp-action@v0.1.7
@@ -92,4 +97,4 @@ jobs:
           script: |
             cd ${{ secrets.TOBY_VPS_BETA_APP_PATH }}/environment/prod/deployment/beta
             make beta-deploy SOPS_AGE_KEY=${{ secrets.SOPS_AGE_BETA_SECRET_KEY }}
-            docker images --filter dangling=true | grep "ghcr.io/blumilksoftware/${{ env.REPO_NAME }}" | awk '{print $3}'| xargs --no-run-if-empty docker rmi
+            docker images --filter dangling=true | grep "${{ env.DOCKER_IMAGE_NAME }}" | awk '{print $3}'| xargs --no-run-if-empty docker rmi

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-22.04
     name: Deploy to production
     env:
-      REPO_NAME: toby
+      DOCKER_REGISTRY: registry.blumilk.pl
+      DOCKER_REGISTRY_USER_NAME: robot@blumilkbot-harbor
+      DOCKER_REGISTRY_PROJECT_NAME: ${{ github.event.repository.name }}
     steps:
       - name: checkout
         uses: actions/checkout@v4.1.4
@@ -29,15 +31,18 @@ jobs:
       - name: login to GitHub Container Registry
         uses: docker/login-action@v3.1.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
+          registry: ${{ env.DOCKER_REGISTRY }}
+          username: ${{ env.DOCKER_REGISTRY_USER_NAME }}
+          password: ${{ secrets.BLUMILKBOT_HARBOR_TOKEN }}
+
+      - name: set docker image name
+        run: echo "DOCKER_IMAGE_NAME=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REGISTRY_PROJECT_NAME }}/${{ env.DOCKER_REGISTRY_PROJECT_NAME }}" >> $GITHUB_ENV
 
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5.5.1
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ env.REPO_NAME }}
+          images: ${{ env.DOCKER_IMAGE_NAME }}
           tags: |
             type=raw,value=latest
             type=raw,value=${{ github.ref_name }}
@@ -50,12 +55,10 @@ jobs:
           file: ./environment/prod/app/Dockerfile
           build-args: DEPLOYMENT_PROJECT_VERSION_ARG=${{ env.DEPLOYMENT_PROJECT_VERSION }}
           labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
           push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/${{ env.REPO_NAME }}:latest
-            ghcr.io/${{ github.repository_owner }}/${{ env.REPO_NAME }}:${{ github.ref_name }}
-          cache-from: type=gha, ref=ghcr.io/${{ github.repository_owner }}/${{ env.REPO_NAME }}-prod-build-cache
-          cache-to: type=gha, ref=ghcr.io/${{ github.repository_owner }}/${{ env.REPO_NAME }}-prod-build-cache, mode=max
+          cache-from: type=gha, ref=${{ env.DOCKER_IMAGE_NAME }}-prod-build-cache
+          cache-to: type=gha, ref=${{ env.DOCKER_IMAGE_NAME }}-prod-build-cache, mode=max
 
       - name: copy files via ssh
         uses: appleboy/scp-action@v0.1.7
@@ -84,4 +87,4 @@ jobs:
           script: |
             cd ${{ secrets.TOBY_VPS_LIVE_APP_PATH }}/environment/prod/deployment/prod
             make prod-deploy SOPS_AGE_KEY=${{ secrets.SOPS_AGE_PROD_SECRET_KEY }}
-            docker images --filter dangling=true | grep "ghcr.io/blumilksoftware/${{ env.REPO_NAME }}" | awk '{print $3}'| xargs --no-run-if-empty docker rmi
+            docker images --filter dangling=true | grep "${{ env.DOCKER_IMAGE_NAME }}" | awk '{print $3}'| xargs --no-run-if-empty docker rmi

--- a/environment/prod/deployment/beta/docker-compose.beta.yml
+++ b/environment/prod/deployment/beta/docker-compose.beta.yml
@@ -14,7 +14,7 @@ volumes:
 
 services:
   toby-beta-app:
-    image: ghcr.io/blumilksoftware/toby:beta
+    image: registry.blumilk.pl/toby/toby:beta
     container_name: toby-beta-app
     pull_policy: always
     deploy:

--- a/environment/prod/deployment/prod/docker-compose.prod.yml
+++ b/environment/prod/deployment/prod/docker-compose.prod.yml
@@ -17,7 +17,7 @@ volumes:
 
 services:
   toby-prod-app:
-    image: ghcr.io/blumilksoftware/toby:latest
+    image: registry.blumilk.pl/toby/toby:latest
     container_name: toby-prod-app
     pull_policy: always
     deploy:

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,20 @@ Application will be running under [localhost:8751](localhost:8751) and [http://t
 | `make cs`         | Runs codestyle checks              |
 | `make fix`        | Runs codestyle fixers              |
 
+### Docker image
+
+App images will be accessible under the following tags:
+
+Beta:
+- `registry.blumilk.pl/toby/toby:beta`
+
+Production image will be accessible in the new registry since `v1.2.1` tag.
+
+Prod:
+- `registry.blumilk.pl/toby/toby:latest`
+- `registry.blumilk.pl/toby/toby:v1.2.3` (depends on releases/tags)
+
+
 ### Further reading
 * [Xdebug configuration](./readme.xdebug.md)
 * [sops configuration](./readme.sops.md)


### PR DESCRIPTION
This PR changes `ghcr.io` registry to `registry.blumilk.pl`.

New images will be stored in our internal docker registry (Harbor). Toby project is publicly accessible.

The image name will be:
- for beta: 
    - `registry.blumilk.pl/toby/toby:beta`
- for prod:
    - `registry.blumilk.pl/toby/toby:latest`
    - `registry.blumilk.pl/toby/toby:v1.2.3` (depends on releases/tags)
---
To discuss:
1. should we move old images from ghcr.io to regostry.blumilk.pl?
2. should we store images in both registries?
3. should we remove all images from ghcr.io when migration to registry.blumilk.pl will be done?
