### PR TITLE
- improve renovate config for manually pined deps

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,5 +5,14 @@
   ],
   "ignoreDeps": [
     "registry.blumilk.pl/toby/toby",
+  ],
+  "packageRules": [
+    {
+      "description": "Manually pined dependency by developers",
+      "matchManagers": ["composer"],
+      "packageName": "phpoffice/phpword",
+      "groupName": "Manually pined phpoffice/phpword",
+      "dependencyDashboardApproval": true,
+    }
   ]
 }


### PR DESCRIPTION
This PR improves Renovate config.

Actually Renovate updates all dependencies even if manually pined (`phpoffice/phpword`) and group them together with non major deps. Thats good because we want to know when new version is available.
This is invalid flow, because there was a reason to pin dependency.

In this case version 1.2.0 breaks something and it will be good to create separate PR (with manual approval in dependency dashboard, before creating PRs by Renovate)

This additional package rule fix this problem. From now package `phpoffice/phpword` will require manually approval and then separate PR will be created.