### PR TITLE
- allow Renovate to update php docker image version

### DIFF
--- a/environment/dev/app/Dockerfile
+++ b/environment/dev/app/Dockerfile
@@ -1,3 +1,4 @@
+# renovate: datasource=docker depName=php
 ARG PHP_VERSION=8.3.6
 ARG PHP_MODULE_NAME=php${PHP_VERSION}
 # https://github.com/nginx/unit/tags

--- a/environment/prod/app/Dockerfile
+++ b/environment/prod/app/Dockerfile
@@ -1,3 +1,4 @@
+# renovate: datasource=docker depName=php
 ARG PHP_VERSION=8.3.6
 ARG PHP_MODULE_NAME=php${PHP_VERSION}
 # https://github.com/nginx/unit/tags


### PR DESCRIPTION
This PR shows Renovate how to update `PHP_VERSION` variable in Dockerfile. 
From now it will be updated via Renovate.

Custom comments use custom managers from default config:
- https://github.com/blumilksoftware/infrastructure/blob/main/renovate/presets/default.json5#L81

This will resolve this issue:
- https://github.com/blumilksoftware/toby/pull/436#pullrequestreview-2075984615