### PR TITLE
- disable pin digest for PHP_VERSION

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,6 +3,9 @@
   "extends": [
     "github>blumilksoftware/infrastructure//renovate/presets/default.json5",
   ],
+  "additionalReviewers": [
+    "Blusia", // Agnieszka Rudek
+  ],
   "ignoreDeps": [
     "registry.blumilk.pl/toby/toby",
   ],
@@ -13,6 +16,23 @@
       "packageName": "phpoffice/phpword",
       "groupName": "Manually pined phpoffice/phpword",
       "dependencyDashboardApproval": true,
-    }
+    },
+    {
+      "description": "Disable digest pinning for regex managers in Dockerfile used for PHP_VERSION upgrading",
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchFileNames": [
+        "environment/dev/app/Dockerfile",
+        "environment/prod/app/Dockerfile",
+      ],
+      "matchDepNames": [
+        "php",
+      ],
+      "pinDigests": false,
+    },
   ]
 }


### PR DESCRIPTION
This PR fixes renovate pin-dependencies flow.

Generic Renovate's custom manager for `_VERSION` variables in Dockerfiles breaks pin-digest flow.

Related issues and discussions:
- https://github.com/renovatebot/renovate/issues/24942
- https://github.com/renovatebot/renovate/discussions/24586

After this fix, Renovate will still update `PHP_VERSION` in Dockerfile, but won't produce errors/warnings related to pin-dependencies PR.

---

**Errors and warnings in dependency dashboard:**
```
WARN: Error updating branch: update failure
```

![image](https://github.com/blumilksoftware/toby/assets/22484267/637a3997-7bac-4635-a4ef-cef0503265a8)


<details>
<summary>Renovate debug logs:</summary>
<pre>

```
2024-05-28T10:55:21.3536341Z DEBUG: getDigest(https://index.docker.io, library/php, 8.3.7-cli-bullseye) (repository=blumilksoftware/toby)
2024-05-28T10:55:21.3541799Z DEBUG: getManifestResponse(https://index.docker.io, library/php, 8.3.7-cli-bullseye, head) (repository=blumilksoftware/toby)
2024-05-28T10:55:21.3551223Z DEBUG: getDigest(https://index.docker.io, library/php, 8.3.7-cli-bullseye) (repository=blumilksoftware/toby)
2024-05-28T10:55:21.3553731Z DEBUG: getManifestResponse(https://index.docker.io, library/php, 8.3.7-cli-bullseye, head) (repository=blumilksoftware/toby)
2024-05-28T10:55:21.3556178Z DEBUG: getDigest(https://index.docker.io, library/php, 8.3.7-cli-bullseye) (repository=blumilksoftware/toby)
2024-05-28T10:55:21.3776393Z DEBUG: getManifestResponse(https://index.docker.io, library/php, 8.3.7-cli-bullseye, head) (repository=blumilksoftware/toby)
2024-05-28T10:55:21.3778441Z DEBUG: getDigest(https://index.docker.io, library/php, 8.3.7-cli-bullseye) (repository=blumilksoftware/toby)
2024-05-28T10:55:21.3780851Z DEBUG: getManifestResponse(https://index.docker.io, library/php, 8.3.7-cli-bullseye, head) (repository=blumilksoftware/toby)
2024-05-28T10:55:21.3782825Z DEBUG: getDigest(https://index.docker.io, library/php, 8.3.7) (repository=blumilksoftware/toby)
2024-05-28T10:55:21.3784588Z DEBUG: getManifestResponse(https://index.docker.io, library/php, 8.3.7, head) (repository=blumilksoftware/toby)
2024-05-28T10:55:21.3786112Z DEBUG: getDigest(https://index.docker.io, library/php, 8.3.7) (repository=blumilksoftware/toby)
2024-05-28T10:55:21.3787686Z DEBUG: getManifestResponse(https://index.docker.io, library/php, 8.3.7, head) (repository=blumilksoftware/toby)
2024-05-28T10:55:21.9025521Z DEBUG: Got docker digest sha256:8c2eaf13528acdcb6d07ee0d3a7b3f6ea5fb52546b806e6a0b851d757488b64d (repository=blumilksoftware/toby)
2024-05-28T10:55:21.9027672Z DEBUG: Got docker digest sha256:8c2eaf13528acdcb6d07ee0d3a7b3f6ea5fb52546b806e6a0b851d757488b64d (repository=blumilksoftware/toby)
2024-05-28T10:55:21.9029617Z DEBUG: Got docker digest sha256:8c2eaf13528acdcb6d07ee0d3a7b3f6ea5fb52546b806e6a0b851d757488b64d (repository=blumilksoftware/toby)
2024-05-28T10:55:21.9031524Z DEBUG: Got docker digest sha256:8c2eaf13528acdcb6d07ee0d3a7b3f6ea5fb52546b806e6a0b851d757488b64d (repository=blumilksoftware/toby)
2024-05-28T10:55:21.9173977Z DEBUG: Got docker digest sha256:83ba95916699325dc60f7e8678c5534b902c8d143b2e64508e7fc72eb6965a9d (repository=blumilksoftware/toby)
2024-05-28T10:55:21.9176017Z DEBUG: Got docker digest sha256:83ba95916699325dc60f7e8678c5534b902c8d143b2e64508e7fc72eb6965a9d (repository=blumilksoftware/toby)


2024-05-28T10:55:23.5869256Z DEBUG: manager.getUpdatedPackageFiles() reuseExistingBranch=false (repository=blumilksoftware/toby, branch=renovate/pin-dependencies)
2024-05-28T10:55:23.5964377Z DEBUG: Starting search at index 0 (repository=blumilksoftware/toby, packageFile=environment/prod/app/Dockerfile, branch=renovate/pin-dependencies)
2024-05-28T10:55:23.5965637Z        "depName": "php"
2024-05-28T10:55:23.5967114Z DEBUG: Found match at index 0 (repository=blumilksoftware/toby, packageFile=environment/prod/app/Dockerfile, branch=renovate/pin-dependencies)
2024-05-28T10:55:23.5968586Z        "depName": "php"
2024-05-28T10:55:23.5989596Z DEBUG: Digest is not updated (repository=blumilksoftware/toby, packageFile=environment/prod/app/Dockerfile, branch=renovate/pin-dependencies)
2024-05-28T10:55:23.5990985Z        "manager": "regex",
2024-05-28T10:55:23.5991866Z        "expectedValue": "sha256:83ba95916699325dc60f7e8678c5534b902c8d143b2e64508e7fc72eb6965a9d",
2024-05-28T10:55:23.5992862Z        "foundValue": undefined
2024-05-28T10:55:23.6014473Z  WARN: Error updating branch: update failure (repository=blumilksoftware/toby, branch=renovate/pin-dependencies)

DEBUG: branches info extended (repository=blumilksoftware/toby)
2024-05-28T10:55:29.0701758Z        "branchesInformation": [
2024-05-28T10:55:29.0702287Z          {
2024-05-28T10:55:29.0702914Z            "branchName": "renovate/pin-dependencies",
2024-05-28T10:55:29.0703557Z            "prNo": null,
2024-05-28T10:55:29.0704633Z            "prTitle": "- Pin dependencies",
2024-05-28T10:55:29.0705260Z            "result": "error",
2024-05-28T10:55:29.0705768Z            "upgrades": [
2024-05-28T10:55:29.0706218Z              {
2024-05-28T10:55:29.0706636Z                "datasource": "docker",
2024-05-28T10:55:29.0707207Z                "depName": "php",
2024-05-28T10:55:29.0707747Z                "displayPending": "",
2024-05-28T10:55:29.0708321Z                "fixedVersion": "8.3.7",
2024-05-28T10:55:29.0708918Z                "currentVersion": "8.3.7",
2024-05-28T10:55:29.0709500Z                "currentValue": "8.3.7",
2024-05-28T10:55:29.0710066Z                "newValue": "8.3.7",
2024-05-28T10:55:29.0710994Z                "newDigest": "sha256:83ba95916699325dc60f7e8678c5534b902c8d143b2e64508e7fc72eb6965a9d",
2024-05-28T10:55:29.0712099Z                "packageFile": "environment/prod/app/Dockerfile",
2024-05-28T10:55:29.0712846Z                "updateType": "pinDigest",
2024-05-28T10:55:29.0741596Z                "packageName": "php"
2024-05-28T10:55:29.0742112Z              },
2024-05-28T10:55:29.0742415Z              {
2024-05-28T10:55:29.0743047Z                "datasource": "docker",
2024-05-28T10:55:29.0743488Z                "depName": "php",
2024-05-28T10:55:29.0743898Z                "displayPending": "",
2024-05-28T10:55:29.0744333Z                "fixedVersion": "8.3.7",
2024-05-28T10:55:29.0744783Z                "currentVersion": "8.3.7",
2024-05-28T10:55:29.0745233Z                "currentValue": "8.3.7",
2024-05-28T10:55:29.0745653Z                "newValue": "8.3.7",
2024-05-28T10:55:29.0746344Z                "newDigest": "sha256:83ba95916699325dc60f7e8678c5534b902c8d143b2e64508e7fc72eb6965a9d",
2024-05-28T10:55:29.0747304Z                "packageFile": "environment/dev/app/Dockerfile",
2024-05-28T10:55:29.0747969Z                "updateType": "pinDigest",
2024-05-28T10:55:29.0748511Z                "packageName": "php"
2024-05-28T10:55:29.0749010Z              },
```

</pre>
</details>


---

**Additionally:**
- added Blusia to the reviewers in Renovate's PRs