### PR TITLE
- fix lazy loading in VacationRequest model

### DIFF
--- a/app/Console/Commands/SendVacationRequestSummariesToApprovers.php
+++ b/app/Console/Commands/SendVacationRequestSummariesToApprovers.php
@@ -33,7 +33,6 @@ class SendVacationRequestSummariesToApprovers extends Command
 
         foreach ($users as $user) {
             $vacationRequests = VacationRequest::query()
-                ->with(["user"])
                 ->states(VacationRequestStatesRetriever::waitingForUserActionStates($user))
                 ->get();
 

--- a/app/Console/Commands/SendVacationRequestSummariesToApprovers.php
+++ b/app/Console/Commands/SendVacationRequestSummariesToApprovers.php
@@ -33,6 +33,7 @@ class SendVacationRequestSummariesToApprovers extends Command
 
         foreach ($users as $user) {
             $vacationRequests = VacationRequest::query()
+                ->with(["user"])
                 ->states(VacationRequestStatesRetriever::waitingForUserActionStates($user))
                 ->get();
 

--- a/app/Notifications/VacationRequestsSummaryNotification.php
+++ b/app/Notifications/VacationRequestsSummaryNotification.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Toby\Notifications;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Collection;
 use Toby\Slack\Elements\SlackMessage;
 use Toby\Slack\Elements\VacationRequestsAttachment;
 
@@ -29,6 +29,8 @@ class VacationRequestsSummaryNotification extends QueuedNotification
 
     public function toSlack(): SlackMessage
     {
+        $this->loadRelations();
+
         return (new SlackMessage())
             ->text(__("Requests wait for your approval - status for day :date:", ["date" => $this->day->toDisplayString()]))
             ->withAttachment(new VacationRequestsAttachment($this->vacationRequests));
@@ -36,6 +38,8 @@ class VacationRequestsSummaryNotification extends QueuedNotification
 
     public function toMail(Notifiable $notifiable): MailMessage
     {
+        $this->loadRelations();
+
         $url = route(
             "vacation.requests.indexForApprovers",
             [
@@ -73,5 +77,10 @@ class VacationRequestsSummaryNotification extends QueuedNotification
 
         return $message
             ->action(__("Go to requests"), $url);
+    }
+
+    protected function loadRelations(): void
+    {
+        $this->vacationRequests->load(["user"]);
     }
 }


### PR DESCRIPTION
This PR fixes lazy loading `user` relation in `VacationRequest` model in queued jobs.

Sentry reports:
```
Illuminate\Database\LazyLoadingViolationException
Attempted to lazy load [user] on model [Toby\Models\VacationRequest] but lazy loading is disabled.
```
- https://blumilk.sentry.io/issues/5139914913/?project=4505271823237120&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=0
- https://blumilk.sentry.io/issues/5139914961/?project=4505271823237120&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=30d&stream_index=1

Places where `user` relation is lazy loaded
- https://github.com/blumilksoftware/toby/blob/main/app/Slack/Elements/VacationRequestsAttachment.php#L33
- https://github.com/blumilksoftware/toby/blob/main/app/Notifications/VacationRequestsSummaryNotification.php#L70

---
Update:

Laravel is able to restore single model relations in queued job during `__unserialize()`. Relations in the collection are not restored by design, see:
- https://github.com/laravel/framework/issues/36824

https://github.com/laravel/framework/blob/11.x/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php#L61-L62

Relations restored in single model:
https://github.com/laravel/framework/blob/11.x/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php#L109

Relations not restored in collection:
https://github.com/laravel/framework/blob/11.x/src/Illuminate/Queue/SerializesAndRestoresModelIdentifiers.php#L81

In this case we need to load required relations manually in queued job after it is unserialized from the queue.
Due to each channel (`toMail()`, `toSlack()`) is a separate job, we have to load relations for each one.

Tested locally and it works.