### PR TITLE
#443 - employment, medical and ohs history

### DIFF
--- a/app/Console/Commands/MigrateProfileDataIntoUserHistory.php
+++ b/app/Console/Commands/MigrateProfileDataIntoUserHistory.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Toby\Console\Commands;
+
+use Illuminate\Console\Command;
+use Toby\Enums\UserHistoryType;
+use Toby\Models\User;
+
+class MigrateProfileDataIntoUserHistory extends Command
+{
+    protected $signature = "toby:move-user-data-to-history";
+    protected $description = "Move profile data to user history";
+
+    public function handle(): void
+    {
+        $users = User::query()
+            ->with("profile")
+            ->get();
+
+        foreach ($users as $user) {
+            $this->moveMedicalDataToHistory($user);
+            $this->moveOhsDataToHistory($user);
+        }
+    }
+
+    private function moveMedicalDataToHistory(User $user): void
+    {
+        if ($user->profile->last_medical_exam_date && $user->profile->next_medical_exam_date) {
+            $user->histories()->create([
+                "from" => $user->profile->last_medical_exam_date,
+                "to" => $user->profile->next_medical_exam_date,
+                "type" => UserHistoryType::MedicalExam,
+            ]);
+        }
+    }
+
+    private function moveOhsDataToHistory(User $user): void
+    {
+        if ($user->profile->last_ohs_training_date && $user->profile->next_ohs_training_date) {
+            $user->histories()->create([
+                "from" => $user->profile->last_ohs_training_date,
+                "to" => $user->profile->next_ohs_training_date,
+                "type" => UserHistoryType::OhsTraining,
+            ]);
+        }
+    }
+}

--- a/app/Enums/UserHistoryType.php
+++ b/app/Enums/UserHistoryType.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Toby\Enums;
+
+enum UserHistoryType: string
+{
+    case Employment = "employment";
+    case MedicalExam = "medical_exam";
+    case OhsTraining = "ohs_training";
+
+    public function label(): string
+    {
+        return __($this->value);
+    }
+
+    public static function casesToSelect(): array
+    {
+        $cases = collect(UserHistoryType::cases());
+
+        return $cases->map(
+            fn(UserHistoryType $enum): array => [
+                "label" => $enum->label(),
+                "value" => $enum->value,
+            ],
+        )->toArray();
+    }
+}

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -31,6 +31,7 @@ class UserController extends Controller
         $status = $request->query("status", "active");
 
         $users = User::query()
+            ->with("histories")
             ->search($searchText)
             ->status($status)
             ->orderByProfileField("last_name")

--- a/app/Http/Controllers/UserHistoryController.php
+++ b/app/Http/Controllers/UserHistoryController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Toby\Http\Controllers;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Response;
+use Toby\Enums\EmploymentForm;
+use Toby\Enums\UserHistoryType;
+use Toby\Http\Requests\UserHistoryRequest;
+use Toby\Http\Resources\UserHistoryResource;
+use Toby\Models\User;
+use Toby\Models\UserHistory;
+
+class UserHistoryController extends Controller
+{
+    public function index(Request $request, User $user): Response
+    {
+        $this->authorize("manageUsers");
+
+        $history = $user->histories()
+            ->orderBy("from", "desc")
+            ->get();
+
+        return inertia("UserHistory/Index", [
+            "history" => UserHistoryResource::collection($history),
+            "userId" => $user->id,
+        ]);
+    }
+
+    public function create(User $user): Response
+    {
+        $this->authorize("manageUsers");
+
+        return inertia("UserHistory/Create", [
+            "types" => UserHistoryType::casesToSelect(),
+            "employmentForms" => EmploymentForm::casesToSelect(),
+            "userId" => $user->id,
+        ]);
+    }
+
+    public function store(UserHistoryRequest $request, User $user): RedirectResponse
+    {
+        $this->authorize("manageUsers");
+
+        $user->histories()->create($request->data());
+
+        return redirect()
+            ->route("users.history", $user)
+            ->with("success", __("User history created."));
+    }
+
+    public function edit(UserHistory $history): Response
+    {
+        $this->authorize("manageUsers");
+
+        return inertia("UserHistory/Edit", [
+            "history" => UserHistoryResource::make($history),
+            "types" => UserHistoryType::casesToSelect(),
+            "employmentForms" => EmploymentForm::casesToSelect(),
+        ]);
+    }
+
+    public function update(UserHistoryRequest $request, UserHistory $history): RedirectResponse
+    {
+        $this->authorize("manageUsers");
+
+        $history->update($request->data());
+
+        return redirect()
+            ->route("users.history", $history->user_id)
+            ->with("success", __("User history updated."));
+    }
+
+    public function destroy(UserHistory $history): RedirectResponse
+    {
+        $this->authorize("manageUsers");
+
+        $history->delete();
+
+        return redirect()
+            ->back()
+            ->with("success", __("User history deleted."));
+    }
+}

--- a/app/Http/Controllers/UserHistoryController.php
+++ b/app/Http/Controllers/UserHistoryController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Toby\Http\Controllers;
 
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 use Inertia\Response;
 use Toby\Enums\EmploymentForm;
 use Toby\Enums\UserHistoryType;
@@ -16,7 +15,7 @@ use Toby\Models\UserHistory;
 
 class UserHistoryController extends Controller
 {
-    public function index(Request $request, User $user): Response
+    public function index(User $user): Response
     {
         $this->authorize("manageUsers");
 

--- a/app/Http/Requests/UserHistoryRequest.php
+++ b/app/Http/Requests/UserHistoryRequest.php
@@ -15,7 +15,7 @@ class UserHistoryRequest extends FormRequest
     {
         return [
             "from" => ["required", "date"],
-            "to" => ["date", "after:from"],
+            "to" => ["nullable", "date", "after:from", "required_if:type," . UserHistoryType::MedicalExam->value . "," . UserHistoryType::OhsTraining->value],
             "comment" => ["nullable", "string", "max:255"],
             "type" => ["required", new Enum(UserHistoryType::class)],
             "employmentForm" => [new Enum(EmploymentForm::class), "required_if:type," . UserHistoryType::Employment->value],

--- a/app/Http/Requests/UserHistoryRequest.php
+++ b/app/Http/Requests/UserHistoryRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Toby\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
+use Toby\Enums\EmploymentForm;
+use Toby\Enums\UserHistoryType;
+
+class UserHistoryRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            "from" => ["required", "date"],
+            "to" => ["date", "after:from"],
+            "type" => ["required", new Enum(UserHistoryType::class)],
+            "employmentForm" => [new Enum(EmploymentForm::class), "required_if:type," . UserHistoryType::Employment->value],
+        ];
+    }
+
+    public function data(): array
+    {
+        return [
+            "from" => $this->get("from"),
+            "to" => $this->get("to"),
+            "type" => $this->get("type"),
+            "employment_form" => $this->get("type") === UserHistoryType::Employment->value ? $this->get("employmentForm") : null,
+        ];
+    }
+}

--- a/app/Http/Requests/UserHistoryRequest.php
+++ b/app/Http/Requests/UserHistoryRequest.php
@@ -16,6 +16,7 @@ class UserHistoryRequest extends FormRequest
         return [
             "from" => ["required", "date"],
             "to" => ["date", "after:from"],
+            "comment" => ["nullable", "string", "max:255"],
             "type" => ["required", new Enum(UserHistoryType::class)],
             "employmentForm" => [new Enum(EmploymentForm::class), "required_if:type," . UserHistoryType::Employment->value],
         ];
@@ -28,6 +29,7 @@ class UserHistoryRequest extends FormRequest
             "to" => $this->get("to"),
             "type" => $this->get("type"),
             "employment_form" => $this->get("type") === UserHistoryType::Employment->value ? $this->get("employmentForm") : null,
+            "comment" => $this->get("comment"),
         ];
     }
 }

--- a/app/Http/Requests/UserRequest.php
+++ b/app/Http/Requests/UserRequest.php
@@ -24,8 +24,6 @@ class UserRequest extends FormRequest
             "employmentDate" => ["required", "date_format:Y-m-d"],
             "birthday" => ["required", "date_format:Y-m-d", "before:today"],
             "slackId" => [],
-            "nextMedicalExamDate" => ["nullable", "after:lastMedicalExamDate"],
-            "nextOhsTrainingDate" => ["nullable", "after:lastOhsTrainingDate"],
         ];
     }
 
@@ -47,10 +45,6 @@ class UserRequest extends FormRequest
             "employment_date" => $this->get("employmentDate"),
             "birthday" => $this->get("birthday"),
             "slack_id" => $this->get("slackId"),
-            "last_medical_exam_date" => $this->get("lastMedicalExamDate"),
-            "next_medical_exam_date" => $this->get("nextMedicalExamDate"),
-            "last_ohs_training_date" => $this->get("lastOhsTrainingDate"),
-            "next_ohs_training_date" => $this->get("nextOhsTrainingDate"),
         ];
     }
 }

--- a/app/Http/Resources/UserHistoryResource.php
+++ b/app/Http/Resources/UserHistoryResource.php
@@ -20,6 +20,7 @@ class UserHistoryResource extends JsonResource
             "typeLabel" => $this->type->label(),
             "employmentFormLabel" => $this->employment_form?->label(),
             "employmentForm" => $this->employment_form?->value,
+            "comment" => $this->comment,
             "userId" => $this->user_id,
         ];
     }

--- a/app/Http/Resources/UserHistoryResource.php
+++ b/app/Http/Resources/UserHistoryResource.php
@@ -14,8 +14,8 @@ class UserHistoryResource extends JsonResource
     {
         return [
             "id" => $this->id,
-            "from" => $this->from->format("Y-m-d"),
-            "to" => $this->to->toDateString("Y-m-d"),
+            "from" => $this->from->format("d-m-Y"),
+            "to" => $this->to->format("d-m-Y"),
             "type" => $this->type->value,
             "typeLabel" => $this->type->label(),
             "employmentFormLabel" => $this->employment_form?->label(),

--- a/app/Http/Resources/UserHistoryResource.php
+++ b/app/Http/Resources/UserHistoryResource.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Toby\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class UserHistoryResource extends JsonResource
+{
+    public static $wrap = null;
+
+    public function toArray($request): array
+    {
+        return [
+            "id" => $this->id,
+            "from" => $this->from->format("Y-m-d"),
+            "to" => $this->to->toDateString("Y-m-d"),
+            "type" => $this->type->value,
+            "typeLabel" => $this->type->label(),
+            "employmentFormLabel" => $this->employment_form?->label(),
+            "employmentForm" => $this->employment_form?->value,
+            "userId" => $this->user_id,
+        ];
+    }
+}

--- a/app/Http/Resources/UserHistoryResource.php
+++ b/app/Http/Resources/UserHistoryResource.php
@@ -14,8 +14,8 @@ class UserHistoryResource extends JsonResource
     {
         return [
             "id" => $this->id,
-            "from" => $this->from->format("d-m-Y"),
-            "to" => $this->to->format("d-m-Y"),
+            "from" => $this->from->format("d.m.Y"),
+            "to" => $this->to?->format("d.m.Y"),
             "type" => $this->type->value,
             "typeLabel" => $this->type->label(),
             "employmentFormLabel" => $this->employment_form?->label(),

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -12,6 +12,9 @@ class UserResource extends JsonResource
 
     public function toArray($request): array
     {
+        $lastMedicalExam = $this->lastMedicalExam();
+        $lastOhsTraining = $this->lastOhsTraining();
+
         return [
             "id" => $this->id,
             "name" => $this->profile->full_name,
@@ -23,10 +26,10 @@ class UserResource extends JsonResource
             "lastActiveAt" => $this->last_active_at?->toDateTimeString(),
             "employmentForm" => $this->profile->employment_form->label(),
             "employmentDate" => $this->profile->employment_date->toDisplayString(),
-            "lastMedicalExamDate" => $this->profile->last_medical_exam_date?->toDisplayString(),
-            "nextMedicalExamDate" => $this->profile->next_medical_exam_date?->toDisplayString(),
-            "lastOhsTrainingDate" => $this->profile->last_ohs_training_date?->toDisplayString(),
-            "nextOhsTrainingDate" => $this->profile->next_ohs_training_date?->toDisplayString(),
+            "lastMedicalExamDate" => $lastMedicalExam?->from->toDisplayString(),
+            "nextMedicalExamDate" => $lastMedicalExam?->to->toDisplayString(),
+            "lastOhsTrainingDate" => $lastOhsTraining?->from->toDisplayString(),
+            "nextOhsTrainingDate" => $lastOhsTraining?->to->toDisplayString(),
         ];
     }
 }

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -26,10 +26,10 @@ class UserResource extends JsonResource
             "lastActiveAt" => $this->last_active_at?->toDateTimeString(),
             "employmentForm" => $this->profile->employment_form->label(),
             "employmentDate" => $this->profile->employment_date->toDisplayString(),
-            "lastMedicalExamDate" => $lastMedicalExam?->from->toDisplayString(),
-            "nextMedicalExamDate" => $lastMedicalExam?->to->toDisplayString(),
-            "lastOhsTrainingDate" => $lastOhsTraining?->from->toDisplayString(),
-            "nextOhsTrainingDate" => $lastOhsTraining?->to->toDisplayString(),
+            "lastMedicalExamDate" => $lastMedicalExam?->from?->toDisplayString(),
+            "nextMedicalExamDate" => $lastMedicalExam?->to?->toDisplayString(),
+            "lastOhsTrainingDate" => $lastOhsTraining?->from?->toDisplayString(),
+            "nextOhsTrainingDate" => $lastOhsTraining?->to?->toDisplayString(),
         ];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -19,6 +19,7 @@ use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
 use Toby\Enums\EmploymentForm;
 use Toby\Enums\Role;
+use Toby\Enums\UserHistoryType;
 use Toby\Notifications\Notifiable as NotifiableInterface;
 
 /**
@@ -78,6 +79,27 @@ class User extends Authenticatable implements NotifiableInterface
     public function vacations(): HasMany
     {
         return $this->hasMany(Vacation::class);
+    }
+
+    public function histories(): HasMany
+    {
+        return $this->hasMany(UserHistory::class);
+    }
+
+    public function lastMedicalExam(): ?UserHistory
+    {
+        return $this->histories()
+            ->where("type", UserHistoryType::MedicalExam)
+            ->orderBy("from", "desc")
+            ->first();
+    }
+
+    public function lastOhsTraining(): ?UserHistory
+    {
+        return $this->histories()
+            ->where("type", UserHistoryType::OhsTraining)
+            ->orderBy("from", "desc")
+            ->first();
     }
 
     public function keys(): HasMany

--- a/app/Models/UserHistory.php
+++ b/app/Models/UserHistory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Toby\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use Toby\Enums\EmploymentForm;
+use Toby\Enums\UserHistoryType;
+
+/**
+ * @property int $id
+ * @property Carbon $from
+ * @property Carbon $to
+ * @property UserHistoryType $type
+ * @property EmploymentForm $employment_form
+ * @property User $user
+ */
+class UserHistory extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+    protected $casts = [
+        "from" => "date:Y-m-d",
+        "to" => "date:Y-m-d",
+        "type" => UserHistoryType::class,
+        "employment_form" => EmploymentForm::class,
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/UserHistory.php
+++ b/app/Models/UserHistory.php
@@ -13,6 +13,8 @@ use Toby\Enums\UserHistoryType;
 
 /**
  * @property int $id
+ * @property int $user_id
+ * @property string $comment
  * @property Carbon $from
  * @property Carbon $to
  * @property UserHistoryType $type

--- a/database/factories/UserHistoryFactory.php
+++ b/database/factories/UserHistoryFactory.php
@@ -24,6 +24,7 @@ class UserHistoryFactory extends Factory
             "to" => $this->faker->date(),
             "type" => $type,
             "employment_form" => $type->is(UserHistoryType::Employment) ? $this->faker->randomElement(EmploymentForm::cases()) : null,
+            "comment" => $this->faker->sentence(),
         ];
     }
 }

--- a/database/factories/UserHistoryFactory.php
+++ b/database/factories/UserHistoryFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Toby\Enums\EmploymentForm;
+use Toby\Enums\UserHistoryType;
+use Toby\Models\User;
+use Toby\Models\UserHistory;
+
+class UserHistoryFactory extends Factory
+{
+    protected $model = UserHistory::class;
+
+    public function definition(): array
+    {
+        $type = $this->faker->randomElement(UserHistoryType::cases());
+
+        return [
+            "user_id" => User::factory(),
+            "from" => $this->faker->date(),
+            "to" => $this->faker->date(),
+            "type" => $type,
+            "employment_form" => $type->is(UserHistoryType::Employment) ? $this->faker->randomElement(EmploymentForm::cases()) : null,
+        ];
+    }
+}

--- a/database/migrations/2024_06_14_112722_add_user_history_table.php
+++ b/database/migrations/2024_06_14_112722_add_user_history_table.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::create("user_histories", function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId("user_id")->constrained()->cascadeOnDelete();
+            $table->date("from");
+            $table->date("to")->nullable();
+            $table->string("type");
+            $table->string("employment_form")->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists("user_histories");
+    }
+};

--- a/database/migrations/2024_06_14_112722_add_user_history_table.php
+++ b/database/migrations/2024_06_14_112722_add_user_history_table.php
@@ -12,6 +12,7 @@ return new class() extends Migration {
         Schema::create("user_histories", function (Blueprint $table): void {
             $table->id();
             $table->foreignId("user_id")->constrained()->cascadeOnDelete();
+            $table->string("comment")->nullable();
             $table->date("from");
             $table->date("to")->nullable();
             $table->string("type");

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -3,6 +3,9 @@
   "employment_contract": "Umowa o pracę",
   "commission_contract": "Umowa zlecenie",
   "b2b_contract": "Kontrakt B2B",
+  "employment": "Zatrudnienie",
+  "medical_exam": "Badanie lekarskie",
+  "ohs_training": "Szkolenie BHP",
   "board_member_contract": "Członek zarządu",
   "vacation": "Urlop wypoczynkowy",
   "vacation_on_request": "Urlop na żądanie",
@@ -182,5 +185,8 @@
   "Labels": "Etykiety",
   "Is mobile": "Czy mobilny",
   "Assignee": "Przypisany do",
-  "Assigned at": "Przypisany od"
+  "Assigned at": "Przypisany od",
+  "User history created.": "Historia użytkownika utworzona.",
+  "User history updated.": "Historia użytkownika zaktualizowana.",
+  "User history deleted.": "Historia użytkownika usunięta."
 }

--- a/lang/pl/validation.php
+++ b/lang/pl/validation.php
@@ -186,6 +186,9 @@ return [
         "employmentForm" => [
             "required_if" => "Forma zatrudnienia jest wymagana.",
         ],
+        "to" => [
+            "required_if" => "Data zakończenia jest wymagana.",
+        ],
     ],
     "attributes" => [
         "to" => "do",

--- a/lang/pl/validation.php
+++ b/lang/pl/validation.php
@@ -187,7 +187,7 @@ return [
             "required_if" => "Forma zatrudnienia jest wymagana.",
         ],
         "to" => [
-            "required_if" => "Data zakończenia jest wymagana.",
+            "required_if" => "Data do jest wymagane.",
         ],
     ],
     "attributes" => [

--- a/lang/pl/validation.php
+++ b/lang/pl/validation.php
@@ -183,6 +183,9 @@ return [
         "birthday" => [
             "before" => "Data urodzenia musi być datą wcześniejszą od dzisiaj.",
         ],
+        "employmentForm" => [
+            "required_if" => "Forma zatrudnienia jest wymagana.",
+        ],
     ],
     "attributes" => [
         "to" => "do",
@@ -200,5 +203,8 @@ return [
         "assignee" => "przydzielona osoba",
         "assignedAt" => "data przydzielenia",
         "birthday" => "data urodzenia",
+        "type" => "typ wpisu",
+        "employmentForm" => "forma zatrudnienia",
+        "comment" => "komentarz",
     ],
 ];

--- a/resources/js/Pages/UserHistory/Create.vue
+++ b/resources/js/Pages/UserHistory/Create.vue
@@ -41,7 +41,6 @@ function createForm() {
           Dodaj wpis
         </h2>
       </div>
-      {{ form }}
       <form
         class="px-6 h-full border-t border-gray-200"
         @submit.prevent="createForm"

--- a/resources/js/Pages/UserHistory/Create.vue
+++ b/resources/js/Pages/UserHistory/Create.vue
@@ -230,7 +230,10 @@ function createForm() {
               for="comment"
               class="block text-sm font-medium text-gray-700 sm:mt-px"
             >
-              Komentarz (opcjonalne)
+              Komentarz
+              <span class="text-xs text-gray-500">
+                (opcjonalny)
+              </span>
             </label>
             <div class="mt-1 sm:col-span-2 sm:mt-0">
               <input

--- a/resources/js/Pages/UserHistory/Create.vue
+++ b/resources/js/Pages/UserHistory/Create.vue
@@ -1,0 +1,248 @@
+<script setup>
+import { useForm } from '@inertiajs/inertia-vue3'
+import FlatPickr from 'vue-flatpickr-component'
+import { Listbox, ListboxButton, ListboxLabel, ListboxOption, ListboxOptions } from '@headlessui/vue'
+import { CheckIcon, ChevronUpDownIcon } from '@heroicons/vue/24/solid'
+
+const props = defineProps({
+  auth: Object,
+  employmentForms: Array,
+  types: Array,
+  userId: Number,
+})
+
+const form = useForm({
+  from: props.vacationFromDate,
+  to: props.vacationFromDate,
+  type: '',
+  employmentForm: '',
+})
+
+function createForm() {
+  form.transform(data => ({
+    employmentForm: data.employmentForm?.value,
+    type: data.type.value,
+    from: data.from,
+    to: data.to,
+  }))
+    .post(`/users/${props.userId}/history`)
+}
+
+</script>
+
+<template>
+  <InertiaHead title="Dodaj wpis" />
+  <div class="mx-auto w-full max-w-7xl">
+    <div class="flex flex-col h-full bg-white shadow-md xl:col-span-2">
+      <div class="p-4 sm:px-6">
+        <h2 class="text-lg font-medium leading-6 text-gray-900">
+          Dodaj wpis
+        </h2>
+      </div>
+      <form
+        class="px-6 h-full border-t border-gray-200"
+        @submit.prevent="createForm"
+      >
+        <div class="flex flex-col justify-around h-full">
+          <div>
+            <Listbox
+              v-model="form.type"
+              as="div"
+              class="items-center py-4 sm:grid sm:grid-cols-3"
+            >
+              <ListboxLabel class="block text-sm font-medium text-gray-700">
+                Typ wpisu
+              </ListboxLabel>
+              <div class="relative mt-1 sm:col-span-2 sm:mt-0">
+                <ListboxButton
+                  :class="{ 'border-red-300 text-red-900 focus:ring-red-500 focus:border-red-500': form.errors.type, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.type }"
+                  class="relative py-2 pr-10 pl-3 w-full max-w-lg text-left bg-white rounded-md border focus:outline-none focus:ring-1 shadow-sm cursor-default sm:text-sm"
+                >
+                  <template v-if="form.type">
+                    <span class="block truncate">
+                      {{ form.type.label }}
+                    </span>
+                    <span class="flex absolute inset-y-0 right-0 items-center pr-2 pointer-events-none">
+                      <ChevronUpDownIcon class="w-5 h-5 text-gray-400" />
+                    </span>
+                  </template>
+                  <template v-else>
+                    <span class="!text-gray-400">Wybierz opcję</span>
+                    <span class="flex absolute inset-y-0 right-0 items-center pr-2 pointer-events-none">
+                      <ChevronUpDownIcon class="w-5 h-5 text-gray-400" />
+                    </span>
+                  </template>
+                </ListboxButton>
+                <transition
+                  leave-active-class="transition ease-in duration-100"
+                  leave-from-class="opacity-100"
+                  leave-to-class="opacity-0"
+                >
+                  <ListboxOptions
+                    class="overflow-auto absolute z-10 py-1 mt-1 w-full max-w-lg max-h-60 text-base bg-white rounded-md focus:outline-none ring-1 ring-black ring-opacity-5 shadow-lg sm:text-sm"
+                  >
+                    <ListboxOption
+                      v-for="type in types"
+                      :key="type.value"
+                      v-slot="{ active, selected }"
+                      :value="type"
+                      as="template"
+                    >
+                      <li :class="[active ? 'bg-gray-100' : 'text-gray-900', 'cursor-default select-none relative py-2 pl-3 pr-9']">
+                        <span :class="[selected ? 'font-semibold' : 'font-normal', 'block truncate']">
+                          {{ type.label }}
+                        </span>
+
+                        <span
+                          v-if="selected"
+                          :class="['text-blumilk-600 absolute inset-y-0 right-0 flex items-center pr-4']"
+                        >
+                          <CheckIcon class="w-5 h-5" />
+                        </span>
+                      </li>
+                    </ListboxOption>
+                  </ListboxOptions>
+                </transition>
+                <p
+                  v-if="form.errors.type"
+                  class="mt-2 text-sm text-red-600"
+                >
+                  {{ form.errors.type }}
+                </p>
+              </div>
+            </Listbox>
+            <Listbox
+              v-if="form.type?.value === 'employment'"
+              v-model="form.employmentForm"
+              as="div"
+              class="items-center py-4 sm:grid sm:grid-cols-3"
+            >
+              <ListboxLabel class="block text-sm font-medium text-gray-700">
+                Forma zatrudnienia
+              </ListboxLabel>
+              <div class="relative mt-1 sm:col-span-2 sm:mt-0">
+                <ListboxButton
+                  :class="{ 'border-red-300 text-red-900 focus:ring-red-500 focus:border-red-500': form.errors.employmentForm, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.type }"
+                  class="relative py-2 pr-10 pl-3 w-full max-w-lg text-left bg-white rounded-md border focus:outline-none focus:ring-1 shadow-sm cursor-default sm:text-sm"
+                >
+                  <template v-if="form.employmentForm">
+                    <span class="block truncate">
+                      {{ form.employmentForm.label }}
+                    </span>
+                    <span class="flex absolute inset-y-0 right-0 items-center pr-2 pointer-events-none">
+                      <ChevronUpDownIcon class="w-5 h-5 text-gray-400" />
+                    </span>
+                  </template>
+                  <template v-else>
+                    <span class="!text-gray-400">Wybierz opcję</span>
+                    <span class="flex absolute inset-y-0 right-0 items-center pr-2 pointer-events-none">
+                      <ChevronUpDownIcon class="w-5 h-5 text-gray-400" />
+                    </span>
+                  </template>
+                </ListboxButton>
+                <transition
+                  leave-active-class="transition ease-in duration-100"
+                  leave-from-class="opacity-100"
+                  leave-to-class="opacity-0"
+                >
+                  <ListboxOptions
+                    class="overflow-auto absolute z-10 py-1 mt-1 w-full max-w-lg max-h-60 text-base bg-white rounded-md focus:outline-none ring-1 ring-black ring-opacity-5 shadow-lg sm:text-sm"
+                  >
+                    <ListboxOption
+                      v-for="form in employmentForms"
+                      :key="form.value"
+                      v-slot="{ active, selected }"
+                      :value="form"
+                      as="template"
+                    >
+                      <li :class="[active ? 'bg-gray-100' : 'text-gray-900', 'cursor-default select-none relative py-2 pl-3 pr-9']">
+                        <span :class="[selected ? 'font-semibold' : 'font-normal', 'block truncate']">
+                          {{ form.label }}
+                        </span>
+
+                        <span
+                          v-if="selected"
+                          :class="['text-blumilk-600 absolute inset-y-0 right-0 flex items-center pr-4']"
+                        >
+                          <CheckIcon class="w-5 h-5" />
+                        </span>
+                      </li>
+                    </ListboxOption>
+                  </ListboxOptions>
+                </transition>
+                <p
+                  v-if="form.errors.employmentForm"
+                  class="mt-2 text-sm text-red-600"
+                >
+                  {{ form.errors.employmentForm }}
+                </p>
+              </div>
+            </Listbox>
+            <div class="items-center py-4 sm:grid sm:grid-cols-3">
+              <label
+                class="block text-sm font-medium text-gray-700 sm:mt-px"
+                for="date_from"
+              >
+                Data od
+              </label>
+              <div class="mt-1 sm:col-span-2 sm:mt-0">
+                <FlatPickr
+                  id="date_from"
+                  v-model="form.from"
+                  :class="{ 'border-red-300 text-red-900 focus:outline-none focus:ring-red-500 focus:border-red-500': form.errors.from, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.from }"
+                  class="block w-full max-w-lg rounded-md shadow-sm sm:text-sm"
+                />
+                <p
+                  v-if="form.errors.from"
+                  class="mt-2 text-sm text-red-600"
+                >
+                  {{ form.errors.from }}
+                </p>
+              </div>
+            </div>
+            <div class="items-center py-4 sm:grid sm:grid-cols-3">
+              <label
+                class="block text-sm font-medium text-gray-700 sm:mt-px"
+                for="date_from"
+              >
+                Data do
+              </label>
+              <div class="mt-1 sm:col-span-2 sm:mt-0">
+                <FlatPickr
+                  id="date_to"
+                  v-model="form.to"
+                  :class="{ 'border-red-300 text-red-900 focus:outline-none focus:ring-red-500 focus:border-red-500': form.errors.to, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.to }"
+                  class="block w-full max-w-lg rounded-md shadow-sm sm:text-sm"
+                />
+                <p
+                  v-if="form.errors.to"
+                  class="mt-2 text-sm text-red-600"
+                >
+                  {{ form.errors.to }}
+                </p>
+              </div>
+            </div>
+          </div>
+          <div class="flex justify-end py-3">
+            <div class="space-x-3">
+              <InertiaLink
+                class="py-2 px-4 text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 rounded-md border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blumilk-500 focus:ring-offset-2 shadow-sm"
+                href="/vacation/requests"
+              >
+                Anuluj
+              </InertiaLink>
+              <button
+                :class="[form.processing ? 'disabled:opacity-60' : 'hover:bg-blumilk-700']"
+                :disabled="form.processing"
+                class="inline-flex justify-center py-2 px-4 text-sm font-medium text-white bg-blumilk-600 rounded-md border border-transparent focus:outline-none focus:ring-2 focus:ring-blumilk-500 focus:ring-offset-2 shadow-sm"
+                type="submit"
+              >
+                Dodaj
+              </button>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>

--- a/resources/js/Pages/UserHistory/Create.vue
+++ b/resources/js/Pages/UserHistory/Create.vue
@@ -230,7 +230,7 @@ function createForm() {
               for="comment"
               class="block text-sm font-medium text-gray-700 sm:mt-px"
             >
-              Komentarz
+              Komentarz (opcjonalne)
             </label>
             <div class="mt-1 sm:col-span-2 sm:mt-0">
               <input

--- a/resources/js/Pages/UserHistory/Create.vue
+++ b/resources/js/Pages/UserHistory/Create.vue
@@ -14,6 +14,7 @@ const props = defineProps({
 const form = useForm({
   from: props.vacationFromDate,
   to: props.vacationFromDate,
+  comment: '',
   type: '',
   employmentForm: '',
 })
@@ -21,6 +22,7 @@ const form = useForm({
 function createForm() {
   form.transform(data => ({
     employmentForm: data.employmentForm?.value,
+    comment: data.comment,
     type: data.type.value,
     from: data.from,
     to: data.to,
@@ -149,15 +151,15 @@ function createForm() {
                     class="overflow-auto absolute z-10 py-1 mt-1 w-full max-w-lg max-h-60 text-base bg-white rounded-md focus:outline-none ring-1 ring-black ring-opacity-5 shadow-lg sm:text-sm"
                   >
                     <ListboxOption
-                      v-for="form in employmentForms"
-                      :key="form.value"
+                      v-for="employmentForm in employmentForms"
+                      :key="employmentForm.value"
                       v-slot="{ active, selected }"
-                      :value="form"
+                      :value="employmentForm"
                       as="template"
                     >
                       <li :class="[active ? 'bg-gray-100' : 'text-gray-900', 'cursor-default select-none relative py-2 pl-3 pr-9']">
                         <span :class="[selected ? 'font-semibold' : 'font-normal', 'block truncate']">
-                          {{ form.label }}
+                          {{ employmentForm.label }}
                         </span>
 
                         <span
@@ -221,6 +223,29 @@ function createForm() {
                   {{ form.errors.to }}
                 </p>
               </div>
+            </div>
+          </div>
+          <div class="items-center py-4 sm:grid sm:grid-cols-3">
+            <label
+              for="comment"
+              class="block text-sm font-medium text-gray-700 sm:mt-px"
+            >
+              Komentarz
+            </label>
+            <div class="mt-1 sm:col-span-2 sm:mt-0">
+              <input
+                id="comment"
+                v-model="form.comment"
+                type="text"
+                class="block w-full max-w-lg rounded-md shadow-sm sm:text-sm"
+                :class="{ 'border-red-300 text-red-900 focus:outline-none focus:ring-red-500 focus:border-red-500': form.errors.comment, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.comment }"
+              >
+              <p
+                v-if="form.errors.comment"
+                class="mt-2 text-sm text-red-600"
+              >
+                {{ form.errors.comment }}
+              </p>
             </div>
           </div>
           <div class="flex justify-end py-3">

--- a/resources/js/Pages/UserHistory/Create.vue
+++ b/resources/js/Pages/UserHistory/Create.vue
@@ -41,6 +41,7 @@ function createForm() {
           Dodaj wpis
         </h2>
       </div>
+      {{ form }}
       <form
         class="px-6 h-full border-t border-gray-200"
         @submit.prevent="createForm"

--- a/resources/js/Pages/UserHistory/Edit.vue
+++ b/resources/js/Pages/UserHistory/Edit.vue
@@ -230,7 +230,10 @@ function updateForm() {
               for="comment"
               class="block text-sm font-medium text-gray-700 sm:mt-px"
             >
-              Komentarz (opcjonalne)
+              Komentarz
+              <span class="text-xs text-gray-500">
+                (opcjonalny)
+              </span>
             </label>
             <div class="mt-1 sm:col-span-2 sm:mt-0">
               <input

--- a/resources/js/Pages/UserHistory/Edit.vue
+++ b/resources/js/Pages/UserHistory/Edit.vue
@@ -16,7 +16,7 @@ const form = useForm({
   to: props.history.to,
   comment: props.history.comment,
   type: props.types.find(type => type.value === props.history.type),
-  employmentForm: props.employmentForms.find(employmentForm => employmentForm.value === props.history.employmentForm),
+  employmentForm: props.employmentForms.find(employmentForm => employmentForm.value === props.history.employmentForm) ?? '',
 })
 
 function updateForm() {
@@ -154,7 +154,7 @@ function updateForm() {
                       v-for="employmentForm in employmentForms"
                       :key="employmentForm.value"
                       v-slot="{ active, selected }"
-                      :value="form"
+                      :value="employmentForm"
                       as="template"
                     >
                       <li :class="[active ? 'bg-gray-100' : 'text-gray-900', 'cursor-default select-none relative py-2 pl-3 pr-9']">

--- a/resources/js/Pages/UserHistory/Edit.vue
+++ b/resources/js/Pages/UserHistory/Edit.vue
@@ -1,0 +1,248 @@
+<script setup>
+import { useForm } from '@inertiajs/inertia-vue3'
+import FlatPickr from 'vue-flatpickr-component'
+import { Listbox, ListboxButton, ListboxLabel, ListboxOption, ListboxOptions } from '@headlessui/vue'
+import { CheckIcon, ChevronUpDownIcon } from '@heroicons/vue/24/solid'
+
+const props = defineProps({
+  auth: Object,
+  employmentForms: Array,
+  types: Array,
+  history: Object,
+})
+
+const form = useForm({
+  from: props.history.from,
+  to: props.history.to,
+  type: props.types.find(type => type.value === props.history.type),
+  employmentForm: props.employmentForms.find(employmentForm => employmentForm.value === props.history.employmentForm),
+})
+
+function updateForm() {
+  form.transform(data => ({
+    employmentForm: data.employmentForm?.value,
+    type: data.type.value,
+    from: data.from,
+    to: data.to,
+  }))
+    .put(`/users/history/${props.history.id}`)
+}
+
+</script>
+
+<template>
+  <InertiaHead title="Dodaj wpis" />
+  <div class="mx-auto w-full max-w-7xl">
+    <div class="flex flex-col h-full bg-white shadow-md xl:col-span-2">
+      <div class="p-4 sm:px-6">
+        <h2 class="text-lg font-medium leading-6 text-gray-900">
+          Edytuj wpis
+        </h2>
+      </div>
+      <form
+        class="px-6 h-full border-t border-gray-200"
+        @submit.prevent="updateForm"
+      >
+        <div class="flex flex-col justify-around h-full">
+          <div>
+            <Listbox
+              v-model="form.type"
+              as="div"
+              class="items-center py-4 sm:grid sm:grid-cols-3"
+            >
+              <ListboxLabel class="block text-sm font-medium text-gray-700">
+                Typ wpisu
+              </ListboxLabel>
+              <div class="relative mt-1 sm:col-span-2 sm:mt-0">
+                <ListboxButton
+                  :class="{ 'border-red-300 text-red-900 focus:ring-red-500 focus:border-red-500': form.errors.type, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.type }"
+                  class="relative py-2 pr-10 pl-3 w-full max-w-lg text-left bg-white rounded-md border focus:outline-none focus:ring-1 shadow-sm cursor-default sm:text-sm"
+                >
+                  <template v-if="form.type">
+                    <span class="block truncate">
+                      {{ form.type.label }}
+                    </span>
+                    <span class="flex absolute inset-y-0 right-0 items-center pr-2 pointer-events-none">
+                      <ChevronUpDownIcon class="w-5 h-5 text-gray-400" />
+                    </span>
+                  </template>
+                  <template v-else>
+                    <span class="!text-gray-400">Wybierz opcję</span>
+                    <span class="flex absolute inset-y-0 right-0 items-center pr-2 pointer-events-none">
+                      <ChevronUpDownIcon class="w-5 h-5 text-gray-400" />
+                    </span>
+                  </template>
+                </ListboxButton>
+                <transition
+                  leave-active-class="transition ease-in duration-100"
+                  leave-from-class="opacity-100"
+                  leave-to-class="opacity-0"
+                >
+                  <ListboxOptions
+                    class="overflow-auto absolute z-10 py-1 mt-1 w-full max-w-lg max-h-60 text-base bg-white rounded-md focus:outline-none ring-1 ring-black ring-opacity-5 shadow-lg sm:text-sm"
+                  >
+                    <ListboxOption
+                      v-for="type in types"
+                      :key="type.value"
+                      v-slot="{ active, selected }"
+                      :value="type"
+                      as="template"
+                    >
+                      <li :class="[active ? 'bg-gray-100' : 'text-gray-900', 'cursor-default select-none relative py-2 pl-3 pr-9']">
+                        <span :class="[selected ? 'font-semibold' : 'font-normal', 'block truncate']">
+                          {{ type.label }}
+                        </span>
+
+                        <span
+                          v-if="selected"
+                          :class="['text-blumilk-600 absolute inset-y-0 right-0 flex items-center pr-4']"
+                        >
+                          <CheckIcon class="w-5 h-5" />
+                        </span>
+                      </li>
+                    </ListboxOption>
+                  </ListboxOptions>
+                </transition>
+                <p
+                  v-if="form.errors.type"
+                  class="mt-2 text-sm text-red-600"
+                >
+                  {{ form.errors.type }}
+                </p>
+              </div>
+            </Listbox>
+            <Listbox
+              v-if="form.type?.value === 'employment'"
+              v-model="form.employmentForm"
+              as="div"
+              class="items-center py-4 sm:grid sm:grid-cols-3"
+            >
+              <ListboxLabel class="block text-sm font-medium text-gray-700">
+                Forma zatrudnienia
+              </ListboxLabel>
+              <div class="relative mt-1 sm:col-span-2 sm:mt-0">
+                <ListboxButton
+                  :class="{ 'border-red-300 text-red-900 focus:ring-red-500 focus:border-red-500': form.errors.employmentForm, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.type }"
+                  class="relative py-2 pr-10 pl-3 w-full max-w-lg text-left bg-white rounded-md border focus:outline-none focus:ring-1 shadow-sm cursor-default sm:text-sm"
+                >
+                  <template v-if="form.employmentForm">
+                    <span class="block truncate">
+                      {{ form.employmentForm.label }}
+                    </span>
+                    <span class="flex absolute inset-y-0 right-0 items-center pr-2 pointer-events-none">
+                      <ChevronUpDownIcon class="w-5 h-5 text-gray-400" />
+                    </span>
+                  </template>
+                  <template v-else>
+                    <span class="!text-gray-400">Wybierz opcję</span>
+                    <span class="flex absolute inset-y-0 right-0 items-center pr-2 pointer-events-none">
+                      <ChevronUpDownIcon class="w-5 h-5 text-gray-400" />
+                    </span>
+                  </template>
+                </ListboxButton>
+                <transition
+                  leave-active-class="transition ease-in duration-100"
+                  leave-from-class="opacity-100"
+                  leave-to-class="opacity-0"
+                >
+                  <ListboxOptions
+                    class="overflow-auto absolute z-10 py-1 mt-1 w-full max-w-lg max-h-60 text-base bg-white rounded-md focus:outline-none ring-1 ring-black ring-opacity-5 shadow-lg sm:text-sm"
+                  >
+                    <ListboxOption
+                      v-for="employmentForm in employmentForms"
+                      :key="employmentForm.value"
+                      v-slot="{ active, selected }"
+                      :value="form"
+                      as="template"
+                    >
+                      <li :class="[active ? 'bg-gray-100' : 'text-gray-900', 'cursor-default select-none relative py-2 pl-3 pr-9']">
+                        <span :class="[selected ? 'font-semibold' : 'font-normal', 'block truncate']">
+                          {{ employmentForm.label }}
+                        </span>
+
+                        <span
+                          v-if="selected"
+                          :class="['text-blumilk-600 absolute inset-y-0 right-0 flex items-center pr-4']"
+                        >
+                          <CheckIcon class="w-5 h-5" />
+                        </span>
+                      </li>
+                    </ListboxOption>
+                  </ListboxOptions>
+                </transition>
+                <p
+                  v-if="form.errors.employmentForm"
+                  class="mt-2 text-sm text-red-600"
+                >
+                  {{ form.errors.employmentForm }}
+                </p>
+              </div>
+            </Listbox>
+            <div class="items-center py-4 sm:grid sm:grid-cols-3">
+              <label
+                class="block text-sm font-medium text-gray-700 sm:mt-px"
+                for="date_from"
+              >
+                Data od
+              </label>
+              <div class="mt-1 sm:col-span-2 sm:mt-0">
+                <FlatPickr
+                  id="date_from"
+                  v-model="form.from"
+                  :class="{ 'border-red-300 text-red-900 focus:outline-none focus:ring-red-500 focus:border-red-500': form.errors.from, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.from }"
+                  class="block w-full max-w-lg rounded-md shadow-sm sm:text-sm"
+                />
+                <p
+                  v-if="form.errors.from"
+                  class="mt-2 text-sm text-red-600"
+                >
+                  {{ form.errors.from }}
+                </p>
+              </div>
+            </div>
+            <div class="items-center py-4 sm:grid sm:grid-cols-3">
+              <label
+                class="block text-sm font-medium text-gray-700 sm:mt-px"
+                for="date_from"
+              >
+                Data do
+              </label>
+              <div class="mt-1 sm:col-span-2 sm:mt-0">
+                <FlatPickr
+                  id="date_to"
+                  v-model="form.to"
+                  :class="{ 'border-red-300 text-red-900 focus:outline-none focus:ring-red-500 focus:border-red-500': form.errors.to, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.to }"
+                  class="block w-full max-w-lg rounded-md shadow-sm sm:text-sm"
+                />
+                <p
+                  v-if="form.errors.to"
+                  class="mt-2 text-sm text-red-600"
+                >
+                  {{ form.errors.to }}
+                </p>
+              </div>
+            </div>
+          </div>
+          <div class="flex justify-end py-3">
+            <div class="space-x-3">
+              <InertiaLink
+                class="py-2 px-4 text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 rounded-md border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blumilk-500 focus:ring-offset-2 shadow-sm"
+                href="/vacation/requests"
+              >
+                Anuluj
+              </InertiaLink>
+              <button
+                :class="[form.processing ? 'disabled:opacity-60' : 'hover:bg-blumilk-700']"
+                :disabled="form.processing"
+                class="inline-flex justify-center py-2 px-4 text-sm font-medium text-white bg-blumilk-600 rounded-md border border-transparent focus:outline-none focus:ring-2 focus:ring-blumilk-500 focus:ring-offset-2 shadow-sm"
+                type="submit"
+              >
+                Dodaj
+              </button>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>

--- a/resources/js/Pages/UserHistory/Edit.vue
+++ b/resources/js/Pages/UserHistory/Edit.vue
@@ -14,6 +14,7 @@ const props = defineProps({
 const form = useForm({
   from: props.history.from,
   to: props.history.to,
+  comment: props.history.comment,
   type: props.types.find(type => type.value === props.history.type),
   employmentForm: props.employmentForms.find(employmentForm => employmentForm.value === props.history.employmentForm),
 })
@@ -21,6 +22,7 @@ const form = useForm({
 function updateForm() {
   form.transform(data => ({
     employmentForm: data.employmentForm?.value,
+    comment: data.comment,
     type: data.type.value,
     from: data.from,
     to: data.to,
@@ -31,7 +33,7 @@ function updateForm() {
 </script>
 
 <template>
-  <InertiaHead title="Dodaj wpis" />
+  <InertiaHead title="Edytuj wpis" />
   <div class="mx-auto w-full max-w-7xl">
     <div class="flex flex-col h-full bg-white shadow-md xl:col-span-2">
       <div class="p-4 sm:px-6">
@@ -223,6 +225,29 @@ function updateForm() {
               </div>
             </div>
           </div>
+          <div class="items-center py-4 sm:grid sm:grid-cols-3">
+            <label
+              for="comment"
+              class="block text-sm font-medium text-gray-700 sm:mt-px"
+            >
+              Komentarz
+            </label>
+            <div class="mt-1 sm:col-span-2 sm:mt-0">
+              <input
+                id="comment"
+                v-model="form.comment"
+                type="text"
+                class="block w-full max-w-lg rounded-md shadow-sm sm:text-sm"
+                :class="{ 'border-red-300 text-red-900 focus:outline-none focus:ring-red-500 focus:border-red-500': form.errors.comment, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.comment }"
+              >
+              <p
+                v-if="form.errors.comment"
+                class="mt-2 text-sm text-red-600"
+              >
+                {{ form.errors.comment }}
+              </p>
+            </div>
+          </div>
           <div class="flex justify-end py-3">
             <div class="space-x-3">
               <InertiaLink
@@ -237,7 +262,7 @@ function updateForm() {
                 class="inline-flex justify-center py-2 px-4 text-sm font-medium text-white bg-blumilk-600 rounded-md border border-transparent focus:outline-none focus:ring-2 focus:ring-blumilk-500 focus:ring-offset-2 shadow-sm"
                 type="submit"
               >
-                Dodaj
+                Zapisz
               </button>
             </div>
           </div>

--- a/resources/js/Pages/UserHistory/Edit.vue
+++ b/resources/js/Pages/UserHistory/Edit.vue
@@ -230,7 +230,7 @@ function updateForm() {
               for="comment"
               class="block text-sm font-medium text-gray-700 sm:mt-px"
             >
-              Komentarz
+              Komentarz (opcjonalne)
             </label>
             <div class="mt-1 sm:col-span-2 sm:mt-0">
               <input

--- a/resources/js/Pages/UserHistory/Index.vue
+++ b/resources/js/Pages/UserHistory/Index.vue
@@ -1,0 +1,155 @@
+<script setup>
+import {
+  EllipsisVerticalIcon,
+  PencilIcon,
+  TrashIcon,
+} from '@heroicons/vue/24/solid'
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue'
+import EmptyState from '@/Shared/Feedbacks/EmptyState.vue'
+
+defineProps({
+  auth: Object,
+  history: Object,
+  userId: Number,
+})
+
+
+</script>
+
+<template>
+  <InertiaHead title="Historia użytkownika" />
+  <div class="bg-white shadow-md">
+    <div class="flex justify-between items-center p-4 sm:px-6">
+      <div>
+        <h2 class="text-lg font-medium leading-6 text-gray-900">
+          Historia
+        </h2>
+      </div>
+      <div>
+        <InertiaLink
+          class="inline-flex items-center py-3 px-4 text-sm font-medium leading-4 text-center text-white bg-blumilk-600 hover:bg-blumilk-700 rounded-md border border-transparent focus:outline-none focus:ring-2 focus:ring-blumilk-500 focus:ring-offset-2 shadow-sm"
+          :href="`/users/${userId}/history/create`"
+        >
+          Dodaj wpis
+        </InertiaLink>
+      </div>
+    </div>
+    <div class="border-t border-gray-200">
+      <div class="overflow-auto 2xl:overflow-visible relative">
+        <table class="min-w-full divide-y divide-gray-200">
+          <thead class="bg-gray-50">
+            <tr>
+              <th
+                class="py-3 px-4 text-xs font-semibold tracking-wider text-left text-gray-500 uppercase whitespace-nowrap"
+                scope="col"
+              >
+                Typ zdarzenia
+              </th>
+              <th
+                class="py-3 px-4 text-xs font-semibold tracking-wider text-left text-gray-500 uppercase whitespace-normal"
+                scope="col"
+              >
+                Od
+              </th>
+              <th
+                class="py-3 px-4 text-xs font-semibold tracking-wider text-left text-gray-500 uppercase whitespace-normal"
+                scope="col"
+              >
+                Do
+              </th>
+              <th
+                class="py-3 px-4 text-xs font-semibold tracking-wider text-left text-gray-500 uppercase whitespace-nowrap"
+                scope="col"
+              />
+            </tr>
+          </thead>
+          <tbody class="bg-white divide-y divide-gray-100">
+            <tr
+              v-for="item in history.data"
+              :key="item.id"
+              class="bg-blumilk-25"
+            >
+              <td class="p-4 text-sm text-gray-500 whitespace-nowrap">
+                {{ item.typeLabel }} <span v-if="item.type === 'employment'">({{ item.employmentFormLabel }})</span>
+              </td>
+              <td class="p-4 text-sm text-gray-500 whitespace-normal">
+                {{ item.from }}
+              </td>
+              <td class="p-4 text-sm text-gray-500 whitespace-nowrap">
+                {{ item.to || '-' }}
+              </td>
+              <td class="p-4 text-sm text-right text-gray-500 whitespace-nowrap">
+                <Menu
+                  as="div"
+                  class="inline-block relative text-left"
+                >
+                  <MenuButton
+                    class="flex items-center text-gray-400 hover:text-gray-600 rounded-full focus:outline-none focus:ring-2 focus:ring-blumilk-500 focus:ring-offset-2 focus:ring-offset-gray-100"
+                  >
+                    <EllipsisVerticalIcon class="w-5 h-5" />
+                  </MenuButton>
+
+                  <transition
+                    enter-active-class="transition ease-out duration-100"
+                    enter-from-class="transform opacity-0 scale-95"
+                    enter-to-class="transform opacity-100 scale-100"
+                    leave-active-class="transition ease-in duration-75"
+                    leave-from-class="transform opacity-100 scale-100"
+                    leave-to-class="transform opacity-0 scale-95"
+                  >
+                    <MenuItems
+                      class="absolute right-0 z-10 mt-2 w-56 bg-white rounded-md focus:outline-none ring-1 ring-black ring-opacity-5 shadow-lg origin-top-right"
+                    >
+                      <MenuItem
+                        v-slot="{ active }"
+                        class="flex"
+                      >
+                        <InertiaLink
+                          :class="[active ? 'bg-gray-100 text-gray-900' : 'text-gray-700', 'font-medium block px-4 py-2 text-sm']"
+                          :href="`/users/history/${item.id}`"
+                        >
+                          <PencilIcon class="mr-2 w-5 h-5 text-blue-500" />
+                          Edytuj
+                        </InertiaLink>
+                      </MenuItem>
+                      <MenuItem
+                        v-slot="{ active }"
+                        class="flex"
+                      >
+                        <InertiaLink
+                          :class="[active ? 'bg-gray-100 text-gray-900' : 'text-gray-700', 'font-medium block px-4 py-2 text-sm']"
+                          :method="'delete'"
+                          :href="`/users/history/${item.id}`"
+                        >
+                          <TrashIcon class="mr-2 w-5 h-5 text-red-500" />
+                          Usuń
+                        </InertiaLink>
+                      </MenuItem>
+                    </MenuItems>
+                  </transition>
+                </Menu>
+              </td>
+            </tr>
+            <tr
+              v-if="!history.data.length"
+            >
+              <td
+                class="py-4 text-xl leading-5 text-center text-gray-700"
+                colspan="100%"
+              >
+                <EmptyState>
+                  <template #title>
+                    Brak wyników
+                  </template>
+                  <template #text>
+                    Dodaj pierwszy wpis
+                  </template>
+                </EmptyState>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</template>

--- a/resources/js/Pages/UserHistory/Index.vue
+++ b/resources/js/Pages/UserHistory/Index.vue
@@ -107,33 +107,35 @@ defineProps({
                     leave-to-class="transform opacity-0 scale-95"
                   >
                     <MenuItems
-                      class="absolute right-0 z-10 mt-2 w-56 bg-white rounded-md focus:outline-none ring-1 ring-black ring-opacity-5 shadow-lg origin-top-right"
+                      class="absolute right-0 z-10 my-2 w-56 bg-white rounded-md focus:outline-none ring-1 ring-black ring-opacity-5 shadow-lg origin-top-right"
                     >
-                      <MenuItem
-                        v-slot="{ active }"
-                        class="flex"
-                      >
-                        <InertiaLink
-                          :class="[active ? 'bg-gray-100 text-gray-900' : 'text-gray-700', 'font-medium block px-4 py-2 text-sm']"
-                          :href="`/users/history/${item.id}`"
+                      <div class="py-1">
+                        <MenuItem
+                          v-slot="{ active }"
+                          class="flex"
                         >
-                          <PencilIcon class="mr-2 w-5 h-5 text-blue-500" />
-                          Edytuj
-                        </InertiaLink>
-                      </MenuItem>
-                      <MenuItem
-                        v-slot="{ active }"
-                        class="flex"
-                      >
-                        <InertiaLink
-                          :class="[active ? 'bg-gray-100 text-gray-900' : 'text-gray-700', 'font-medium block px-4 py-2 text-sm']"
-                          :method="'delete'"
-                          :href="`/users/history/${item.id}`"
+                          <InertiaLink
+                            :class="[active ? 'bg-gray-100 text-gray-900' : 'text-gray-700', 'font-medium block px-4 py-2 text-sm']"
+                            :href="`/users/history/${item.id}`"
+                          >
+                            <PencilIcon class="mr-2 w-5 h-5 text-blue-500" />
+                            Edytuj
+                          </InertiaLink>
+                        </MenuItem>
+                        <MenuItem
+                          v-slot="{ active }"
+                          class="flex"
                         >
-                          <TrashIcon class="mr-2 w-5 h-5 text-red-500" />
-                          Usuń
-                        </InertiaLink>
-                      </MenuItem>
+                          <InertiaLink
+                            :class="[active ? 'bg-gray-100 text-gray-900' : 'text-gray-700', 'font-medium block px-4 py-2 text-sm']"
+                            :method="'delete'"
+                            :href="`/users/history/${item.id}`"
+                          >
+                            <TrashIcon class="mr-2 w-5 h-5 text-red-500" />
+                            Usuń
+                          </InertiaLink>
+                        </MenuItem>
+                      </div>
                     </MenuItems>
                   </transition>
                 </Menu>

--- a/resources/js/Pages/UserHistory/Index.vue
+++ b/resources/js/Pages/UserHistory/Index.vue
@@ -49,6 +49,12 @@ defineProps({
                 class="py-3 px-4 text-xs font-semibold tracking-wider text-left text-gray-500 uppercase whitespace-normal"
                 scope="col"
               >
+                Komentarz
+              </th>
+              <th
+                class="py-3 px-4 text-xs font-semibold tracking-wider text-left text-gray-500 uppercase whitespace-normal"
+                scope="col"
+              >
                 Od
               </th>
               <th
@@ -71,6 +77,9 @@ defineProps({
             >
               <td class="p-4 text-sm text-gray-500 whitespace-nowrap">
                 {{ item.typeLabel }} <span v-if="item.type === 'employment'">({{ item.employmentFormLabel }})</span>
+              </td>
+              <td class="p-4 text-sm text-gray-500 whitespace-nowrap">
+                {{ item.comment || '-' }}
               </td>
               <td class="p-4 text-sm text-gray-500 whitespace-normal">
                 {{ item.from }}

--- a/resources/js/Pages/Users/Create.vue
+++ b/resources/js/Pages/Users/Create.vue
@@ -19,10 +19,6 @@ const form = useForm({
   employmentDate: null,
   birthday: null,
   slackId: null,
-  lastMedicalExamDate: null,
-  nextMedicalExamDate: null,
-  lastOhsTrainingDate: null,
-  nextOhsTrainingDate: null,
 })
 
 function createUser() {
@@ -313,94 +309,6 @@ function createUser() {
             class="mt-2 text-sm text-red-600"
           >
             {{ form.errors.birthday }}
-          </p>
-        </div>
-      </div>
-      <div class="items-center py-4 sm:grid sm:grid-cols-3">
-        <label
-          for="last_medical_exam_date"
-          class="block text-sm font-medium text-gray-700 sm:mt-px"
-        >
-          Data ostatniego badania lekarskiego
-        </label>
-        <div class="mt-1 sm:col-span-2 sm:mt-0">
-          <FlatPickr
-            id="last_medical_exam_date"
-            v-model="form.lastMedicalExamDate"
-            class="block w-full max-w-lg rounded-md shadow-sm sm:text-sm"
-            :class="{ 'border-red-300 text-red-900 focus:outline-none focus:ring-red-500 focus:border-red-500': form.errors.lastMedicalExamDate, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.lastMedicalExamDate }"
-          />
-          <p
-            v-if="form.errors.lastMedicalExamDate"
-            class="mt-2 text-sm text-red-600"
-          >
-            {{ form.errors.lastMedicalExamDate }}
-          </p>
-        </div>
-      </div>
-      <div class="items-center py-4 sm:grid sm:grid-cols-3">
-        <label
-          for="next_medical_exam_date"
-          class="block text-sm font-medium text-gray-700 sm:mt-px"
-        >
-          Data następnego badania lekarskiego
-        </label>
-        <div class="mt-1 sm:col-span-2 sm:mt-0">
-          <FlatPickr
-            id="next_medical_exam_date"
-            v-model="form.nextMedicalExamDate"
-            class="block w-full max-w-lg rounded-md shadow-sm sm:text-sm"
-            :class="{ 'border-red-300 text-red-900 focus:outline-none focus:ring-red-500 focus:border-red-500': form.errors.nextMedicalExamDate, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.nextMedicalExamDate }"
-          />
-          <p
-            v-if="form.errors.nextMedicalExamDate"
-            class="mt-2 text-sm text-red-600"
-          >
-            {{ form.errors.nextMedicalExamDate }}
-          </p>
-        </div>
-      </div>
-      <div class="items-center py-4 sm:grid sm:grid-cols-3">
-        <label
-          for="last_ohs_training_date"
-          class="block text-sm font-medium text-gray-700 sm:mt-px"
-        >
-          Data ostatniego szkolenia BHP
-        </label>
-        <div class="mt-1 sm:col-span-2 sm:mt-0">
-          <FlatPickr
-            id="last_ohs_training_date"
-            v-model="form.lastOhsTrainingDate"
-            class="block w-full max-w-lg rounded-md shadow-sm sm:text-sm"
-            :class="{ 'border-red-300 text-red-900 focus:outline-none focus:ring-red-500 focus:border-red-500': form.errors.lastOhsTrainingDate, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.lastOhsTrainingDate }"
-          />
-          <p
-            v-if="form.errors.lastOhsTrainingDate"
-            class="mt-2 text-sm text-red-600"
-          >
-            {{ form.errors.lastOhsTrainingDate }}
-          </p>
-        </div>
-      </div>
-      <div class="items-center py-4 sm:grid sm:grid-cols-3">
-        <label
-          for="next_ohs_training_date"
-          class="block text-sm font-medium text-gray-700 sm:mt-px"
-        >
-          Data następnego szkolenia BHP
-        </label>
-        <div class="mt-1 sm:col-span-2 sm:mt-0">
-          <FlatPickr
-            id="next_ohs_training_date"
-            v-model="form.nextOhsTrainingDate"
-            class="block w-full max-w-lg rounded-md shadow-sm sm:text-sm"
-            :class="{ 'border-red-300 text-red-900 focus:outline-none focus:ring-red-500 focus:border-red-500': form.errors.nextOhsTrainingDate, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.nextOhsTrainingDate }"
-          />
-          <p
-            v-if="form.errors.nextOhsTrainingDate"
-            class="mt-2 text-sm text-red-600"
-          >
-            {{ form.errors.nextOhsTrainingDate }}
           </p>
         </div>
       </div>

--- a/resources/js/Pages/Users/Edit.vue
+++ b/resources/js/Pages/Users/Edit.vue
@@ -20,10 +20,6 @@ const form = useForm({
   employmentDate: props.user.employmentDate,
   birthday: props.user.birthday,
   slackId: props.user.slackId,
-  lastMedicalExamDate: props.user.lastMedicalExamDate,
-  nextMedicalExamDate: props.user.nextMedicalExamDate,
-  lastOhsTrainingDate: props.user.lastOhsTrainingDate,
-  nextOhsTrainingDate: props.user.nextOhsTrainingDate,
 })
 
 function editUser() {
@@ -321,94 +317,6 @@ function editUser() {
             class="mt-2 text-sm text-red-600"
           >
             {{ form.errors.slackId }}
-          </p>
-        </div>
-      </div>
-      <div class="items-center py-4 sm:grid sm:grid-cols-3">
-        <label
-          for="last_medical_exam_date"
-          class="block text-sm font-medium text-gray-700 sm:mt-px"
-        >
-          Data ostatniego badania lekarskiego
-        </label>
-        <div class="mt-1 sm:col-span-2 sm:mt-0">
-          <FlatPickr
-            id="last_medical_exam_date"
-            v-model="form.lastMedicalExamDate"
-            class="block w-full max-w-lg rounded-md shadow-sm sm:text-sm"
-            :class="{ 'border-red-300 text-red-900 focus:outline-none focus:ring-red-500 focus:border-red-500': form.errors.lastMedicalExamDate, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.lastMedicalExamDate }"
-          />
-          <p
-            v-if="form.errors.lastMedicalExamDate"
-            class="mt-2 text-sm text-red-600"
-          >
-            {{ form.errors.lastMedicalExamDate }}
-          </p>
-        </div>
-      </div>
-      <div class="items-center py-4 sm:grid sm:grid-cols-3">
-        <label
-          for="next_medical_exam_date"
-          class="block text-sm font-medium text-gray-700 sm:mt-px"
-        >
-          Data następnego badania lekarskiego
-        </label>
-        <div class="mt-1 sm:col-span-2 sm:mt-0">
-          <FlatPickr
-            id="next_medical_exam_date"
-            v-model="form.nextMedicalExamDate"
-            class="block w-full max-w-lg rounded-md shadow-sm sm:text-sm"
-            :class="{ 'border-red-300 text-red-900 focus:outline-none focus:ring-red-500 focus:border-red-500': form.errors.nextMedicalExamDate, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.nextMedicalExamDate }"
-          />
-          <p
-            v-if="form.errors.nextMedicalExamDate"
-            class="mt-2 text-sm text-red-600"
-          >
-            {{ form.errors.nextMedicalExamDate }}
-          </p>
-        </div>
-      </div>
-      <div class="items-center py-4 sm:grid sm:grid-cols-3">
-        <label
-          for="last_ohs_training_date"
-          class="block text-sm font-medium text-gray-700 sm:mt-px"
-        >
-          Data ostatniego szkolenia BHP
-        </label>
-        <div class="mt-1 sm:col-span-2 sm:mt-0">
-          <FlatPickr
-            id="last_ohs_training_date"
-            v-model="form.lastOhsTrainingDate"
-            class="block w-full max-w-lg rounded-md shadow-sm sm:text-sm"
-            :class="{ 'border-red-300 text-red-900 focus:outline-none focus:ring-red-500 focus:border-red-500': form.errors.lastOhsTrainingDate, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.lastOhsTrainingDate }"
-          />
-          <p
-            v-if="form.errors.lastOhsTrainingDate"
-            class="mt-2 text-sm text-red-600"
-          >
-            {{ form.errors.lastOhsTrainingDate }}
-          </p>
-        </div>
-      </div>
-      <div class="items-center py-4 sm:grid sm:grid-cols-3">
-        <label
-          for="next_ohs_training_date"
-          class="block text-sm font-medium text-gray-700 sm:mt-px"
-        >
-          Data następnego szkolenia BHP
-        </label>
-        <div class="mt-1 sm:col-span-2 sm:mt-0">
-          <FlatPickr
-            id="next_ohs_training_date"
-            v-model="form.nextOhsTrainingDate"
-            class="block w-full max-w-lg rounded-md shadow-sm sm:text-sm"
-            :class="{ 'border-red-300 text-red-900 focus:outline-none focus:ring-red-500 focus:border-red-500': form.errors.nextOhsTrainingDate, 'focus:ring-blumilk-500 focus:border-blumilk-500 sm:text-sm border-gray-300': !form.errors.nextOhsTrainingDate }"
-          />
-          <p
-            v-if="form.errors.nextOhsTrainingDate"
-            class="mt-2 text-sm text-red-600"
-          >
-            {{ form.errors.nextOhsTrainingDate }}
           </p>
         </div>
       </div>

--- a/resources/js/Pages/Users/Index.vue
+++ b/resources/js/Pages/Users/Index.vue
@@ -3,7 +3,7 @@ import { ref, watch, computed, reactive } from 'vue'
 import { Inertia } from '@inertiajs/inertia'
 import { debounce } from 'lodash'
 import { MagnifyingGlassIcon } from '@heroicons/vue/24/outline'
-import { EllipsisVerticalIcon, PencilIcon, NoSymbolIcon, ArrowPathIcon, ChevronUpDownIcon, CheckIcon, LockClosedIcon } from '@heroicons/vue/24/solid'
+import { EllipsisVerticalIcon, PencilIcon, NoSymbolIcon, ArrowPathIcon, ChevronUpDownIcon, CheckIcon, LockClosedIcon, ClockIcon } from '@heroicons/vue/24/solid'
 import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/vue'
 import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/vue'
 import { DateTime } from 'luxon'
@@ -311,6 +311,17 @@ watch(form, debounce(() => {
                             :class="[active ? 'bg-gray-100 text-gray-900' : 'text-gray-700', 'font-medium block px-4 py-2 text-sm']"
                           >
                             <LockClosedIcon class="mr-2 w-5 h-5 text-yellow-500" /> Uprawnienia
+                          </InertiaLink>
+                        </MenuItem>
+                        <MenuItem
+                          v-slot="{ active }"
+                          class="flex"
+                        >
+                          <InertiaLink
+                            :href="`/users/${user.id}/history`"
+                            :class="[active ? 'bg-gray-100 text-gray-900' : 'text-gray-700', 'font-medium block px-4 py-2 text-sm']"
+                          >
+                            <ClockIcon class="mr-2 w-5 h-5 text-violet-500" /> Historia
                           </InertiaLink>
                         </MenuItem>
                         <MenuItem

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,6 +24,7 @@ use Toby\Http\Controllers\SelectYearPeriodController;
 use Toby\Http\Controllers\TechnologyController;
 use Toby\Http\Controllers\TimesheetController;
 use Toby\Http\Controllers\UserController;
+use Toby\Http\Controllers\UserHistoryController;
 use Toby\Http\Controllers\VacationCalendarController;
 use Toby\Http\Controllers\VacationLimitController;
 use Toby\Http\Controllers\VacationRequestController;
@@ -45,6 +46,19 @@ Route::middleware(["auth", TrackUserLastActivity::class])->group(function (): vo
         ->whereNumber("user");
     Route::patch("/users/{user}/permissions", [PermissionController::class, "update"])
         ->whereNumber("user");
+    Route::get("/users/{user}/history", [UserHistoryController::class, "index"])
+        ->whereNumber("user")
+        ->name("users.history");
+    Route::get("/users/{user}/history/create", [UserHistoryController::class, "create"])
+        ->whereNumber("user");
+    Route::post("/users/{user}/history", [UserHistoryController::class, "store"])
+        ->whereNumber("user");
+    Route::get("/users/history/{history}", [UserHistoryController::class, "edit"])
+        ->whereNumber("history");
+    Route::put("/users/history/{history}", [UserHistoryController::class, "update"])
+        ->whereNumber("history");
+    Route::delete("/users/history/{history}", [UserHistoryController::class, "destroy"])
+        ->whereNumber("history");
 
     Route::resource("equipment-items", EquipmentController::class)
         ->except("show")

--- a/tests/Feature/UserHistoryTest.php
+++ b/tests/Feature/UserHistoryTest.php
@@ -52,6 +52,7 @@ class UserHistoryTest extends FeatureTestCase
                 "to" => Carbon::now()->subDays(50)->format("Y-m-d"),
                 "type" => UserHistoryType::Employment->value,
                 "employmentForm" => EmploymentForm::EmploymentContract->value,
+                "comment" => "Test comment",
             ])
             ->assertRedirect("/users/{$this->user->id}/history");
 
@@ -61,6 +62,7 @@ class UserHistoryTest extends FeatureTestCase
             "to" => Carbon::now()->subDays(50)->format("Y-m-d"),
             "type" => UserHistoryType::Employment->value,
             "employment_form" => EmploymentForm::EmploymentContract->value,
+            "comment" => "Test comment",
         ]);
     }
 
@@ -82,6 +84,7 @@ class UserHistoryTest extends FeatureTestCase
                 "from" => Carbon::now()->subDays(200)->format("Y-m-d"),
                 "to" => Carbon::now()->subDays(70)->format("Y-m-d"),
                 "type" => UserHistoryType::MedicalExam->value,
+                "comment" => "Test comment",
             ])
             ->assertRedirect("/users/{$this->user->id}/history");
 
@@ -90,6 +93,7 @@ class UserHistoryTest extends FeatureTestCase
             "from" => Carbon::now()->subDays(200)->format("Y-m-d"),
             "to" => Carbon::now()->subDays(70)->format("Y-m-d"),
             "type" => UserHistoryType::MedicalExam->value,
+            "comment" => "Test comment",
         ]);
     }
 

--- a/tests/Feature/UserHistoryTest.php
+++ b/tests/Feature/UserHistoryTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Support\Carbon;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\FeatureTestCase;
+use Toby\Enums\EmploymentForm;
+use Toby\Enums\UserHistoryType;
+use Toby\Models\User;
+
+class UserHistoryTest extends FeatureTestCase
+{
+    use DatabaseMigrations;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->admin = User::factory()
+            ->admin()
+            ->create();
+        $this->user = User::factory()
+            ->create();
+        $this->userHistory = $this->user->histories()->create([
+            "from" => Carbon::now()->subDays(10),
+            "to" => Carbon::now()->subDays(5),
+            "type" => UserHistoryType::Employment,
+            "employment_form" => EmploymentForm::EmploymentContract,
+        ]);
+    }
+
+    public function testAdminCanSeeUserHistoryList(): void
+    {
+        $this->actingAs($this->admin)
+            ->get("/users/{$this->user->id}/history")
+            ->assertInertia(
+                fn(Assert $page) => $page
+                    ->component("UserHistory/Index")
+                    ->has("history.data", 1),
+            );
+    }
+
+    public function testAdminCanCreateUserHistory(): void
+    {
+        $this->actingAs($this->admin)
+            ->post("/users/{$this->user->id}/history", [
+                "from" => Carbon::now()->subDays(100)->format("Y-m-d"),
+                "to" => Carbon::now()->subDays(50)->format("Y-m-d"),
+                "type" => UserHistoryType::Employment->value,
+                "employmentForm" => EmploymentForm::EmploymentContract->value,
+            ])
+            ->assertRedirect("/users/{$this->user->id}/history");
+
+        $this->assertDatabaseHas("user_histories", [
+            "user_id" => $this->user->id,
+            "from" => Carbon::now()->subDays(100)->format("Y-m-d"),
+            "to" => Carbon::now()->subDays(50)->format("Y-m-d"),
+            "type" => UserHistoryType::Employment->value,
+            "employment_form" => EmploymentForm::EmploymentContract->value,
+        ]);
+    }
+
+    public function testAdminCanEditUserHistory(): void
+    {
+        $this->actingAs($this->admin)
+            ->get("/users/history/{$this->userHistory->id}")
+            ->assertInertia(
+                fn(Assert $page) => $page
+                    ->component("UserHistory/Edit")
+                    ->has("history"),
+            );
+    }
+
+    public function testAdminCanUpdateUserHistory(): void
+    {
+        $this->actingAs($this->admin)
+            ->put("/users/history/{$this->userHistory->id}", [
+                "from" => Carbon::now()->subDays(200)->format("Y-m-d"),
+                "to" => Carbon::now()->subDays(70)->format("Y-m-d"),
+                "type" => UserHistoryType::MedicalExam->value,
+            ])
+            ->assertRedirect("/users/{$this->user->id}/history");
+
+        $this->assertDatabaseHas("user_histories", [
+            "user_id" => $this->user->id,
+            "from" => Carbon::now()->subDays(200)->format("Y-m-d"),
+            "to" => Carbon::now()->subDays(70)->format("Y-m-d"),
+            "type" => UserHistoryType::MedicalExam->value,
+        ]);
+    }
+
+    public function testAdminCanDeleteUserHistory(): void
+    {
+        $this->actingAs($this->admin)
+            ->delete("/users/history/{$this->userHistory->id}");
+
+        $this->assertDatabaseMissing("user_histories", [
+            "id" => $this->userHistory->id,
+        ]);
+    }
+}


### PR DESCRIPTION
Should close #443.
Added option for administrator to manage users `employment`, `medical exams` and `ohs trainings` history.
Added artisan `toby:move-user-data-to-history` command for migrate data about `ohs training` and `medical exam` into user history.
Added tests.

Preview:

[Screencast from 18-06-24 09:24:19.webm](https://github.com/blumilksoftware/toby/assets/29115024/8d502c1d-c84e-4831-9514-61eef00d171c)
