### PR TITLE
- change harbor image name

### DIFF
--- a/.github/workflows/deploy-to-beta-manually.yml
+++ b/.github/workflows/deploy-to-beta-manually.yml
@@ -16,7 +16,8 @@ jobs:
     env:
       DOCKER_REGISTRY: registry.blumilk.pl
       DOCKER_REGISTRY_USER_NAME: robot@blumilkbot-harbor
-      DOCKER_REGISTRY_PROJECT_NAME: ${{ github.event.repository.name }}
+      DOCKER_REGISTRY_PROJECT_NAME: internal-public
+      DOCKER_REGISTRY_REPO_NAME: toby
     steps:
       - name: set branch name
         run: echo "BRANCH_NAME=$GITHUB_REF_NAME" >> $GITHUB_ENV
@@ -47,7 +48,7 @@ jobs:
           password: ${{ secrets.BLUMILKBOT_HARBOR_TOKEN }}
 
       - name: set docker image name
-        run: echo "DOCKER_IMAGE_NAME=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REGISTRY_PROJECT_NAME }}/${{ env.DOCKER_REGISTRY_PROJECT_NAME }}" >> $GITHUB_ENV
+        run: echo "DOCKER_IMAGE_NAME=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REGISTRY_PROJECT_NAME }}/${{ env.DOCKER_REGISTRY_REPO_NAME }}" >> $GITHUB_ENV
 
       - name: Docker meta
         id: meta
@@ -55,7 +56,7 @@ jobs:
         with:
           images: ${{ env.DOCKER_IMAGE_NAME }}
           tags: type=raw,value=beta
-          context: git
+          context: workflow
 
       - name: build and push image
         uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -17,7 +17,8 @@ jobs:
     env:
       DOCKER_REGISTRY: registry.blumilk.pl
       DOCKER_REGISTRY_USER_NAME: robot@blumilkbot-harbor
-      DOCKER_REGISTRY_PROJECT_NAME: ${{ github.event.repository.name }}
+      DOCKER_REGISTRY_PROJECT_NAME: internal-public
+      DOCKER_REGISTRY_REPO_NAME: toby
     steps:
       - name: checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
@@ -36,7 +37,7 @@ jobs:
           password: ${{ secrets.BLUMILKBOT_HARBOR_TOKEN }}
 
       - name: set docker image name
-        run: echo "DOCKER_IMAGE_NAME=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REGISTRY_PROJECT_NAME }}/${{ env.DOCKER_REGISTRY_PROJECT_NAME }}" >> $GITHUB_ENV
+        run: echo "DOCKER_IMAGE_NAME=${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_REGISTRY_PROJECT_NAME }}/${{ env.DOCKER_REGISTRY_REPO_NAME }}" >> $GITHUB_ENV
 
       - name: Docker meta
         id: meta

--- a/environment/prod/deployment/beta/docker-compose.beta.yml
+++ b/environment/prod/deployment/beta/docker-compose.beta.yml
@@ -14,7 +14,7 @@ volumes:
 
 services:
   toby-beta-app:
-    image: registry.blumilk.pl/toby/toby:beta
+    image: registry.blumilk.pl/internal-public/toby:beta
     container_name: toby-beta-app
     pull_policy: always
     deploy:

--- a/environment/prod/deployment/prod/docker-compose.prod.yml
+++ b/environment/prod/deployment/prod/docker-compose.prod.yml
@@ -17,7 +17,7 @@ volumes:
 
 services:
   toby-prod-app:
-    image: registry.blumilk.pl/toby/toby:latest
+    image: registry.blumilk.pl/internal-public/toby:latest
     container_name: toby-prod-app
     pull_policy: always
     deploy:

--- a/readme.md
+++ b/readme.md
@@ -39,13 +39,11 @@ Application will be running under [localhost:8751](localhost:8751) and [http://t
 App images will be accessible under the following tags:
 
 Beta:
-- `registry.blumilk.pl/toby/toby:beta`
-
-Production image will be accessible in the new registry since `v1.2.1` tag.
+- `registry.blumilk.pl/internal-public/toby:beta`
 
 Prod:
-- `registry.blumilk.pl/toby/toby:latest`
-- `registry.blumilk.pl/toby/toby:v1.2.3` (depends on releases/tags)
+- `registry.blumilk.pl/internal-public/toby:latest`
+- `registry.blumilk.pl/internal-public/toby:v1.2.3` (depends on releases/tags)
 
 
 ### Further reading

--- a/renovate.json5
+++ b/renovate.json5
@@ -7,7 +7,7 @@
     "Blusia", // Agnieszka Rudek
   ],
   "ignoreDeps": [
-    "registry.blumilk.pl/toby/toby",
+    "registry.blumilk.pl/internal-public/toby",
   ],
   "packageRules": [
     {


### PR DESCRIPTION
This PR changes docker image name in Harbor registry.

Before:
- `registry.blumilk.pl/toby/toby`

After:
- `registry.blumilk.pl/internal-public/toby`

`internal-public` project in Harbor has been already created.