### PR TITLE
#444 - add notification to Slack about overtime

### DIFF
--- a/app/Console/Commands/SendOvertimeRequestSummariesToApprovers.php
+++ b/app/Console/Commands/SendOvertimeRequestSummariesToApprovers.php
@@ -9,7 +9,6 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
 use Spatie\Permission\Models\Permission;
 use Toby\Domain\OvertimeRequestStatesRetriever;
-use Toby\Domain\VacationTypeConfigRetriever;
 use Toby\Models\Holiday;
 use Toby\Models\OvertimeRequest;
 use Toby\Models\User;
@@ -20,7 +19,7 @@ class SendOvertimeRequestSummariesToApprovers extends Command
     protected $signature = "toby:send-overtime-request-reminders {--f|force}";
     protected $description = "Sends overtime request reminders to approvers if they didn't approve";
 
-    public function handle(VacationTypeConfigRetriever $configRetriever): void
+    public function handle(): void
     {
         $now = Carbon::today();
 

--- a/app/Console/Commands/SendOvertimeRequestSummariesToApprovers.php
+++ b/app/Console/Commands/SendOvertimeRequestSummariesToApprovers.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Toby\Console\Commands;
+
+use Carbon\CarbonInterface;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Spatie\Permission\Models\Permission;
+use Toby\Domain\OvertimeRequestStatesRetriever;
+use Toby\Domain\VacationTypeConfigRetriever;
+use Toby\Models\Holiday;
+use Toby\Models\OvertimeRequest;
+use Toby\Models\User;
+use Toby\Notifications\OvertimeRequestsSummaryNotification;
+
+class SendOvertimeRequestSummariesToApprovers extends Command
+{
+    protected $signature = "toby:send-overtime-request-reminders {--f|force}";
+    protected $description = "Sends overtime request reminders to approvers if they didn't approve";
+
+    public function handle(VacationTypeConfigRetriever $configRetriever): void
+    {
+        $now = Carbon::today();
+
+        if (!$this->option("force") && !$this->shouldHandle($now)) {
+            return;
+        }
+
+        $users = Permission::findByName("receiveOvertimeRequestsSummaryNotification")->users()->get();
+
+        foreach ($users as $user) {
+            $overtimeRequests = OvertimeRequest::query()
+                ->states(OvertimeRequestStatesRetriever::waitingForUserActionStates($user))
+                ->orderByDesc("updated_at")
+                ->get();
+
+            if ($overtimeRequests->isNotEmpty() && $this->worksToday($user, $now)) {
+                $user->notify(new OvertimeRequestsSummaryNotification(Carbon::today(), $overtimeRequests));
+            }
+        }
+    }
+
+    protected function shouldHandle(CarbonInterface $day): bool
+    {
+        $holidays = Holiday::query()->whereDate("date", $day)->pluck("date");
+
+        if ($day->isWeekend()) {
+            return false;
+        }
+
+        if ($holidays->contains($day)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function worksToday(User $user, Carbon $date): bool
+    {
+        $count = $user->overtimeRequests()
+            ->whereDate("from", "<=", $date)
+            ->whereDate("to", ">=", $date)
+            ->states(OvertimeRequestStatesRetriever::successStates())
+            ->count();
+
+        return $count === 0;
+    }
+}

--- a/app/Console/Commands/SendVacationRequestSummariesToApprovers.php
+++ b/app/Console/Commands/SendVacationRequestSummariesToApprovers.php
@@ -34,6 +34,7 @@ class SendVacationRequestSummariesToApprovers extends Command
         foreach ($users as $user) {
             $vacationRequests = VacationRequest::query()
                 ->states(VacationRequestStatesRetriever::waitingForUserActionStates($user))
+                ->orderByDesc("updated_at")
                 ->get();
 
             if ($vacationRequests->isNotEmpty() && $this->worksToday($user, $now, $configRetriever)) {

--- a/app/Notifications/OvertimeRequestNotification.php
+++ b/app/Notifications/OvertimeRequestNotification.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Toby\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Toby\Models\OvertimeRequest;
+use Toby\Models\User;
+use Toby\Slack\Elements\SlackMessage;
+
+abstract class OvertimeRequestNotification extends QueuedNotification
+{
+    use Queueable;
+
+    public function __construct(
+        protected OvertimeRequest $overtimeRequest,
+        protected User $user,
+    ) {
+        parent::__construct();
+    }
+
+    public function via(): array
+    {
+        return [Channels::SLACK];
+    }
+
+    public function toSlack(): SlackMessage
+    {
+        $url = route("overtime.requests.show", ["overtimeRequest" => $this->overtimeRequest->id]);
+        $seeDetails = __("See details");
+
+        return (new SlackMessage())
+            ->text("{$this->buildDescription()}\n <{$url}|{$seeDetails}>");
+    }
+
+    abstract protected function buildDescription(): string;
+}

--- a/app/Notifications/OvertimeRequestsSummaryNotification.php
+++ b/app/Notifications/OvertimeRequestsSummaryNotification.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Toby\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Carbon;
+use Toby\Slack\Elements\OvertimeRequestsAttachment;
+use Toby\Slack\Elements\SlackMessage;
+
+class OvertimeRequestsSummaryNotification extends QueuedNotification
+{
+    use Queueable;
+
+    public function __construct(
+        protected Carbon $day,
+        protected Collection $overtimeRequests,
+    ) {
+        parent::__construct();
+    }
+
+    public function via(): array
+    {
+        return [Channels::SLACK];
+    }
+
+    public function toSlack(): SlackMessage
+    {
+        $this->loadRelations();
+
+        return (new SlackMessage())
+            ->text(__("Requests wait for your approval - status for day :date:", ["date" => $this->day->toDisplayString()]))
+            ->withAttachment(new OvertimeRequestsAttachment($this->overtimeRequests));
+    }
+
+    protected function loadRelations(): void
+    {
+        $this->overtimeRequests->load(["user"]);
+    }
+}

--- a/app/Notifications/OvertimeRequestsWaitsForApprovalNotification.php
+++ b/app/Notifications/OvertimeRequestsWaitsForApprovalNotification.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Toby\Notifications;
+
+use Spatie\SlashCommand\AttachmentAction;
+use Toby\Helpers\DateFormats;
+use Toby\Slack\Elements\Attachment;
+use Toby\Slack\Elements\SlackMessage;
+
+class OvertimeRequestsWaitsForApprovalNotification extends OvertimeRequestNotification
+{
+    public function toSlack(): SlackMessage
+    {
+        $url = route("overtime.requests.show", ["overtimeRequest" => $this->overtimeRequest->id]);
+        $seeDetails = __("See details");
+
+        $actions = [
+            AttachmentAction::create("overtime_technical_approval", __("Approve"), "button")
+                ->setValue("overtime_technical_approval")
+                ->setStyle("primary"),
+            AttachmentAction::create("overtime_reject", __("Reject"), "button")
+                ->setValue("overtime_reject")
+                ->setStyle("danger"),
+        ];
+
+        $attachment = Attachment::create()
+            ->setCallbackId("overtime:{$this->overtimeRequest->id}")
+            ->setText(__("Available actions:"))
+            ->setActions($actions);
+
+        return (new SlackMessage())
+            ->text("{$this->buildDescription()}\n <{$url}|{$seeDetails}>")
+            ->withAttachment($attachment);
+    }
+
+    protected function buildDescription(): string
+    {
+        $title = $this->overtimeRequest->name;
+        $requester = $this->overtimeRequest->user->profile->full_name;
+        $from = $this->overtimeRequest->from;
+        $to = $this->overtimeRequest->to;
+        $hours = $this->overtimeRequest->hours;
+
+        $date = "{$from->format(DateFormats::DATETIME_DISPLAY)} - {$to->format(DateFormats::DATETIME_DISPLAY)}";
+
+        return __("The request :title is waiting for your technical approval.\nUser: :requester\nDate: :date (number of hours: :hours)", [
+            "title" => $title,
+            "requester" => $requester,
+            "date" => $date,
+            "hours" => $hours,
+        ]);
+    }
+}

--- a/app/Notifications/VacationRequestWaitsForApprovalNotification.php
+++ b/app/Notifications/VacationRequestWaitsForApprovalNotification.php
@@ -38,7 +38,7 @@ class VacationRequestWaitsForApprovalNotification extends VacationRequestNotific
         }
 
         $attachment = Attachment::create()
-            ->setCallbackId((string)$this->vacationRequest->id)
+            ->setCallbackId("vacation:{$this->vacationRequest->id}")
             ->setText(__("Available actions:"))
             ->setActions($actions);
 

--- a/app/Slack/Elements/OvertimeRequestsAttachment.php
+++ b/app/Slack/Elements/OvertimeRequestsAttachment.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Toby\Slack\Elements;
+
+use Illuminate\Support\Collection;
+use Toby\Helpers\DateFormats;
+use Toby\Models\OvertimeRequest;
+
+class OvertimeRequestsAttachment extends ListAttachment
+{
+    public function __construct(Collection $overtimeRequests)
+    {
+        parent::__construct();
+
+        $this
+            ->setColor("#527aba")
+            ->setItems($this->mapOvertimeRequests($overtimeRequests));
+    }
+
+    protected function mapOvertimeRequests(Collection $overtimeRequests): Collection
+    {
+        return $overtimeRequests->map(function (OvertimeRequest $request): string {
+            $url = route("overtime.requests.show", ["overtimeRequest" => $request->id]);
+
+            $date = "{$request->from->format(DateFormats::DATETIME_DISPLAY)} - {$request->to->format(DateFormats::DATETIME_DISPLAY)}";
+
+            return __("<:url|:request> - :user (:date)", [
+                "url" => $url,
+                "request" => $request->name,
+                "user" => $request->user->profile->full_name,
+                "date" => $date,
+            ]);
+        });
+    }
+}

--- a/config/permission.php
+++ b/config/permission.php
@@ -61,6 +61,7 @@ return [
         "receiveVacationRequestStatusChangedNotification",
         "receiveBenefitsReportCreationNotification",
         "manageEquipment",
+        "receiveOvertimeRequestsSummaryNotification",
     ],
     "permission_roles" => [
         Role::Administrator->value => [
@@ -85,6 +86,7 @@ return [
             "receiveVacationRequestWaitsForApprovalNotification",
             "receiveVacationRequestStatusChangedNotification",
             "manageEquipment",
+            "receiveOvertimeRequestsSummaryNotification",
         ],
         Role::AdministrativeApprover->value => [
             "managePermissions",
@@ -120,6 +122,7 @@ return [
             "receiveVacationRequestsSummaryNotification",
             "receiveVacationRequestWaitsForApprovalNotification",
             "receiveVacationRequestStatusChangedNotification",
+            "receiveOvertimeRequestsSummaryNotification",
         ],
         Role::Employee->value => [],
     ],

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -193,5 +193,8 @@
   "Assigned at": "Przypisany od",
   "User history created.": "Historia użytkownika utworzona.",
   "User history updated.": "Historia użytkownika zaktualizowana.",
-  "User history deleted.": "Historia użytkownika usunięta."
+  "User history deleted.": "Historia użytkownika usunięta.",
+  "settled": "rozliczony",
+  "The request :title is waiting for your technical approval.\nUser: :requester\nDate: :date (number of hours: :hours)": "Wniosek :title czeka na Twoją akceptację techniczną.\nPracownik: :requester\nData: :date (liczba godzin: :hours)",
+  "The request :title has been approved by you as a technical approver.\nUser: :requester\nDate: :date (number of hours: :hours)": "Wniosek :title został zaakceptowany przez Ciebie jako przełożonego technicznego.\nPracownik: :requester\nData: :date (liczba godzin: :hours)"
 }

--- a/resources/js/Composables/permissionInfo.js
+++ b/resources/js/Composables/permissionInfo.js
@@ -119,6 +119,11 @@ const permissionsInfo = [
     'value': 'receiveVacationRequestStatusChangedNotification',
     'section': 'Powiadomienia',
   },
+  {
+    'name': 'Podsumowania wniosków o nadgodziny',
+    'value': 'receiveOvertimeRequestsSummaryNotification',
+    'section': 'Powiadomienia',
+  },
 ]
 
 export function usePermissionInfo() {

--- a/resources/js/Pages/OvertimeRequest/Show.vue
+++ b/resources/js/Pages/OvertimeRequest/Show.vue
@@ -190,7 +190,7 @@ defineProps({
               preserve-scroll
               class="inline-flex justify-center items-center py-2 px-4 font-medium text-blue-700 bg-blue-100 hover:bg-blue-200 rounded-md border border-transparent focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 sm:text-sm"
             >
-              Rozlicz nadogdziny
+              Rozlicz nadgodziny
             </InertiaLink>
           </div>
         </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,7 +13,7 @@ use Toby\Slack\SlackActionController;
 use Toby\Slack\SlackCommandController;
 
 Route::post("slack/commands", [SlackCommandController::class, "getResponse"]);
-Route::post("slack/actions", [SlackActionController::class, "handleVacationRequestAction"]);
+Route::post("slack/actions", [SlackActionController::class, "handleAction"]);
 
 Route::middleware("auth:sanctum")->group(function (): void {
     Route::post("vacation/calculate-days", CalculateVacationDaysController::class);

--- a/routes/console.php
+++ b/routes/console.php
@@ -9,6 +9,7 @@ use Toby\Console\Commands\SendDailySummaryToSlack;
 use Toby\Console\Commands\SendNotificationAboutBenefitsReportCreation;
 use Toby\Console\Commands\SendNotificationAboutUpcomingAndOverdueMedicalExams;
 use Toby\Console\Commands\SendNotificationAboutUpcomingAndOverdueOhsTraining;
+use Toby\Console\Commands\SendOvertimeRequestSummariesToApprovers;
 use Toby\Console\Commands\SendVacationRequestSummariesToApprovers;
 use Toby\Jobs\CheckYearPeriod;
 
@@ -19,6 +20,11 @@ Schedule::command(SendDailySummaryToSlack::class)
     ->onOneServer();
 
 Schedule::command(SendVacationRequestSummariesToApprovers::class)
+    ->weekdays()
+    ->dailyAt("08:30")
+    ->onOneServer();
+
+Schedule::command(SendOvertimeRequestSummariesToApprovers::class)
     ->weekdays()
     ->dailyAt("08:30")
     ->onOneServer();

--- a/tests/Feature/PermissionTest.php
+++ b/tests/Feature/PermissionTest.php
@@ -49,7 +49,8 @@ class PermissionTest extends FeatureTestCase
                             ->where("receiveVacationRequestsSummaryNotification", false)
                             ->where("receiveVacationRequestWaitsForApprovalNotification", false)
                             ->where("receiveVacationRequestStatusChangedNotification", false)
-                            ->where("manageEquipment", false),
+                            ->where("manageEquipment", false)
+                            ->where("receiveOvertimeRequestsSummaryNotification", false),
                     ),
             );
     }
@@ -90,7 +91,8 @@ class PermissionTest extends FeatureTestCase
                             ->where("receiveVacationRequestsSummaryNotification", true)
                             ->where("receiveVacationRequestWaitsForApprovalNotification", true)
                             ->where("receiveVacationRequestStatusChangedNotification", true)
-                            ->where("manageEquipment", false),
+                            ->where("manageEquipment", false)
+                            ->where("receiveOvertimeRequestsSummaryNotification", true),
                     ),
             );
     }
@@ -131,7 +133,8 @@ class PermissionTest extends FeatureTestCase
                             ->where("receiveVacationRequestsSummaryNotification", true)
                             ->where("receiveVacationRequestWaitsForApprovalNotification", true)
                             ->where("receiveVacationRequestStatusChangedNotification", true)
-                            ->where("manageEquipment", true),
+                            ->where("manageEquipment", true)
+                            ->where("receiveOvertimeRequestsSummaryNotification", false),
                     ),
             );
     }

--- a/tests/Unit/SendOvertimeRequestSummariesTest.php
+++ b/tests/Unit/SendOvertimeRequestSummariesTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+use Tests\Traits\InteractsWithYearPeriods;
+use Toby\Console\Commands\SendOvertimeRequestSummariesToApprovers;
+use Toby\Models\OvertimeRequest;
+use Toby\Models\User;
+use Toby\Models\YearPeriod;
+use Toby\Notifications\OvertimeRequestsSummaryNotification;
+use Toby\States\OvertimeRequest\Approved;
+use Toby\States\OvertimeRequest\Cancelled;
+use Toby\States\OvertimeRequest\Created;
+use Toby\States\OvertimeRequest\Rejected;
+use Toby\States\OvertimeRequest\Settled;
+use Toby\States\OvertimeRequest\WaitingForTechnical;
+
+class SendOvertimeRequestSummariesTest extends TestCase
+{
+    use RefreshDatabase;
+    use InteractsWithYearPeriods;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Notification::fake();
+        $this->createCurrentYearPeriod();
+        $this->travelTo(now()->startOfWeek());
+    }
+
+    public function testSummariesAreSentOnlyToProperApprovers(): void
+    {
+        $currentYearPeriod = YearPeriod::current();
+
+        $user = User::factory()->employee()->create();
+        $technicalApprover = User::factory()->technicalApprover()->create();
+        $administrativeApprover = User::factory()->administrativeApprover()->create();
+        $admin = User::factory()->admin()->create();
+
+        OvertimeRequest::factory()
+            ->for($user)
+            ->for($currentYearPeriod)
+            ->create(["state" => WaitingForTechnical::class]);
+
+        $this->artisan(SendOvertimeRequestSummariesToApprovers::class)
+            ->execute();
+
+        Notification::assertSentTo([$technicalApprover, $admin], OvertimeRequestsSummaryNotification::class);
+        Notification::assertNotSentTo([$user, $administrativeApprover], OvertimeRequestsSummaryNotification::class);
+    }
+
+    public function testSummariesAreNotSentOnWeekends(): void
+    {
+        $this->travelTo(now()->endOfWeek());
+        $currentYearPeriod = YearPeriod::current();
+
+        $user = User::factory()->employee()->create();
+
+        OvertimeRequest::factory()
+            ->for($user)
+            ->for($currentYearPeriod)
+            ->create(["state" => WaitingForTechnical::class]);
+
+        $this->artisan(SendOvertimeRequestSummariesToApprovers::class)
+            ->execute();
+
+        Notification::assertNothingSent();
+    }
+
+    public function testSummariesAreSentOnlyIfOvertimeRequestWaitingForActionExists(): void
+    {
+        $currentYearPeriod = YearPeriod::current();
+
+        $user = User::factory()->employee()->create();
+        $technicalApprover = User::factory()->technicalApprover()->create();
+        $admin = User::factory()->admin()->create();
+
+        OvertimeRequest::factory()
+            ->for($user)
+            ->for($currentYearPeriod)
+            ->create(["state" => WaitingForTechnical::class]);
+
+        $this->artisan(SendOvertimeRequestSummariesToApprovers::class)
+            ->execute();
+
+        Notification::assertSentTo([$technicalApprover, $admin], OvertimeRequestsSummaryNotification::class);
+        Notification::assertNotSentTo([$user], OvertimeRequestsSummaryNotification::class);
+    }
+
+    public function testSummariesAreNotSentIfThereAreNoWaitingForActionOvertimeRequests(): void
+    {
+        $currentYearPeriod = YearPeriod::current();
+
+        $user = User::factory()->employee()->create();
+        $technicalApprover = User::factory()->technicalApprover()->create();
+        $admin = User::factory()->admin()->create();
+
+        OvertimeRequest::factory()
+            ->for($user)
+            ->for($currentYearPeriod)
+            ->create(["state" => Approved::class]);
+
+        OvertimeRequest::factory()
+            ->for($user)
+            ->for($currentYearPeriod)
+            ->create(["state" => Cancelled::class]);
+
+        OvertimeRequest::factory()
+            ->for($user)
+            ->for($currentYearPeriod)
+            ->create(["state" => Rejected::class]);
+
+        OvertimeRequest::factory()
+            ->for($user)
+            ->for($currentYearPeriod)
+            ->create(["state" => Created::class]);
+
+        OvertimeRequest::factory()
+            ->for($user)
+            ->for($currentYearPeriod)
+            ->create(["state" => Settled::class]);
+
+        $this->artisan(SendOvertimeRequestSummariesToApprovers::class)
+            ->execute();
+
+        Notification::assertNotSentTo([$user, $technicalApprover, $admin], OvertimeRequestsSummaryNotification::class);
+    }
+}


### PR DESCRIPTION
In this pr I added Slack notification about overtime requests. Now from Slack the technical approver/user with right permission can approve or reject overtime.

![image](https://github.com/blumilksoftware/toby/assets/56546832/38783dd9-8f27-40b4-8380-1dc1bffc6e85)

Also I added notification with overtimes waiting for approval. It works very similar to vacation requests - every weekday about 8:30 users with right permissions will receive information about overtimes that waits for approval.

![image](https://github.com/user-attachments/assets/f1415122-bdbd-4f67-b8d3-e15cb6d917dd)

This should finally close #444.