### PR TITLE
- add navigation to page with employee equipment

### DIFF
--- a/resources/js/Pages/Equipment/IndexForEmployee.vue
+++ b/resources/js/Pages/Equipment/IndexForEmployee.vue
@@ -11,6 +11,7 @@ import {
   XMarkIcon,
   ComputerDesktopIcon,
 } from '@heroicons/vue/24/solid'
+import AppLayout from '@/Shared/Layout/AppLayout.vue'
 
 const props = defineProps({
   equipmentItems: Object,

--- a/resources/js/Pages/Users/Show.vue
+++ b/resources/js/Pages/Users/Show.vue
@@ -6,7 +6,6 @@ import { ComputerDesktopIcon } from '@heroicons/vue/24/outline'
 import EmptyState from '@/Shared/Feedbacks/EmptyState.vue'
 import UserOvertimeRequests from '@/Shared/Widgets/UserOvertimeRequests.vue'
 import InertiaLink from '@/Shared/InertiaLink.vue'
-import AppLayout from '@/Shared/Layout/AppLayout.vue'
 import UserLayout from '@/Shared/Layout/UserLayout.vue'
 
 const props = defineProps({


### PR DESCRIPTION
In this pr:
- added import AppLayout to page `IndexForEmployee`
- remove unused import from `UserShow`