### PR TITLE
- fix double notifications

### DIFF
--- a/app/Actions/VacationRequest/ApproveAction.php
+++ b/app/Actions/VacationRequest/ApproveAction.php
@@ -35,7 +35,10 @@ class ApproveAction
 
     protected function notify(VacationRequest $vacationRequest): void
     {
-        $users = Permission::findByName("receiveVacationRequestStatusChangedNotification")->users()->get();
+        $users = Permission::findByName("receiveVacationRequestStatusChangedNotification")
+            ->users()
+            ->where("id", "!=", $vacationRequest->user->id)
+            ->get();
 
         foreach ($users as $user) {
             $user->notify(new VacationRequestStatusChangedNotification($vacationRequest, $user));

--- a/app/Actions/VacationRequest/CancelAction.php
+++ b/app/Actions/VacationRequest/CancelAction.php
@@ -35,7 +35,10 @@ class CancelAction
 
     protected function notify(VacationRequest $vacationRequest): void
     {
-        $users = Permission::findByName("receiveVacationRequestStatusChangedNotification")->users()->get();
+        $users = Permission::findByName("receiveVacationRequestStatusChangedNotification")
+            ->users()
+            ->where("id", "!=", $vacationRequest->user->id)
+            ->get();
 
         foreach ($users as $user) {
             $user->notify(new VacationRequestStatusChangedNotification($vacationRequest, $user));


### PR DESCRIPTION
In the `ApproveAction` and `CancelAction`, users with permission to receive notifications about vacation requests were receiving duplicate notifications if they were also the request submitter.