### PR TITLE
- adjust new blumilk environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,7 @@ MAIL_FROM_NAME="${APP_NAME}"
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_CALENDAR_ENABLED=true
-GOOGLE_REDIRECT=https://toby.blumilk.localhost/login/google/end
+GOOGLE_REDIRECT=http://localhost:301/https://toby.blumilk.local.env/login/google/end
 GOOGLE_CALENDAR_ID=
 LOCAL_EMAIL_FOR_LOGIN_VIA_GOOGLE=
 

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ APP_NAME="Toby HR application"
 APP_ENV=local
 APP_KEY=base64:GOwYei8d8m8gubf1JaBxjBlQjeVCG+7n4fZwcgq76V8=
 APP_DEBUG=true
-APP_URL=https://toby.blumilk.localhost
+APP_URL=https://toby.blumilk.local.env
 
 COMPOSE_PROJECT_NAME=toby-dev
 
@@ -64,7 +64,10 @@ DOCKER_DEV_DB_USERNAME=${DB_USERNAME}
 DOCKER_DEV_DB_PASSWORD=${DB_PASSWORD}
 DOCKER_DEV_DB_ROOT_PASSWORD=${DB_ROOT_PASSWORD}
 
-SANCTUM_STATEFUL_DOMAINS=toby.blumilk.localhost
+APP_DOCKER_HOST_NAME=toby.blumilk.local.env
+MAILPIT_DOCKER_HOST_NAME=toby-mailpit.blumilk.local.env
+
+SANCTUM_STATEFUL_DOMAINS=toby.blumilk.local.env
 
 SOPS_AGE_BETA_SECRET_KEY=
 SOPS_AGE_PROD_SECRET_KEY=

--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,7 @@ DOCKER_DEV_DB_ROOT_PASSWORD=${DB_ROOT_PASSWORD}
 
 APP_DOCKER_HOST_NAME=toby.blumilk.local.env
 MAILPIT_DOCKER_HOST_NAME=toby-mailpit.blumilk.local.env
+VITE_DEV_SERVER_DOCKER_HOST_NAME=toby-vite-dev-server.blumilk.local.env
 
 SANCTUM_STATEFUL_DOMAINS=toby.blumilk.local.env
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       # APP LOADBALANCER
       - "traefik.http.services.toby-app.loadbalancer.server.port=80"
       # VITE DEV SERVER
-      - "traefik.http.routers.toby-vite-dev-server-https-router.rule=Host(`toby-vite-dev-server.blumilk.local.env`)"
+      - "traefik.http.routers.toby-vite-dev-server-https-router.rule=Host(`${VITE_DEV_SERVER_DOCKER_HOST_NAME}`)"
       - "traefik.http.routers.toby-vite-dev-server-https-router.entrypoints=websecure"
       - "traefik.http.routers.toby-vite-dev-server-https-router.tls=true"
       - "traefik.http.routers.toby-vite-dev-server-https-router.service=toby-vite-dev-server"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,16 +8,26 @@ services:
         - USER_ID=${DOCKER_HOST_USER_ID:-1000}
     labels:
       - "traefik.enable=true"
-      - "traefik.blumilk.environment=true"
+      - "traefik.blumilk.local.environment=true"
       # HTTP
-      - "traefik.http.routers.toby-http-router.rule=Host(`toby.blumilk.localhost`)"
+      - "traefik.http.routers.toby-http-router.rule=Host(`${APP_DOCKER_HOST_NAME}`)"
       - "traefik.http.routers.toby-http-router.entrypoints=web"
+      - "traefik.http.routers.toby-http-router.service=toby-app"
       # HTTP to HTTPS redirect
-      #      - "traefik.http.routers.toby-http-router.middlewares=https-redirect@file"
+      #- "traefik.http.routers.toby-http-router.middlewares=https-redirect@file"
       # HTTPS
-      - "traefik.http.routers.toby-https-router.rule=Host(`toby.blumilk.localhost`)"
+      - "traefik.http.routers.toby-https-router.rule=Host(`${APP_DOCKER_HOST_NAME}`)"
       - "traefik.http.routers.toby-https-router.entrypoints=websecure"
       - "traefik.http.routers.toby-https-router.tls=true"
+      - "traefik.http.routers.toby-https-router.service=toby-app"
+      # APP LOADBALANCER
+      - "traefik.http.services.toby-app.loadbalancer.server.port=80"
+      # VITE DEV SERVER
+      - "traefik.http.routers.toby-vite-dev-server-https-router.rule=Host(`toby-vite-dev-server.blumilk.local.env`)"
+      - "traefik.http.routers.toby-vite-dev-server-https-router.entrypoints=websecure"
+      - "traefik.http.routers.toby-vite-dev-server-https-router.tls=true"
+      - "traefik.http.routers.toby-vite-dev-server-https-router.service=toby-vite-dev-server"
+      - "traefik.http.services.toby-vite-dev-server.loadbalancer.server.port=5173"
     container_name: toby-app-dev
     working_dir: /application
     volumes:
@@ -29,7 +39,7 @@ services:
       - ${DOCKER_APP_HOST_PORT:-8751}:80
     networks:
       - toby-dev
-      - traefik-proxy-blumilk-local
+      - traefik-proxy-blumilk-local-environment
     restart: unless-stopped
     depends_on:
       database:
@@ -79,14 +89,14 @@ services:
     container_name: toby-mailpit-dev
     labels:
       - "traefik.enable=true"
-      - "traefik.blumilk.environment=true"
+      - "traefik.blumilk.local.environment=true"
       # HTTP
-      - "traefik.http.routers.toby-mailpit-http-router.rule=Host(`toby-mailpit.blumilk.localhost`)"
+      - "traefik.http.routers.toby-mailpit-http-router.rule=Host(`${MAILPIT_DOCKER_HOST_NAME}`)"
       - "traefik.http.routers.toby-mailpit-http-router.entrypoints=web"
       # HTTP to HTTPS redirect
-#      - "traefik.http.routers.toby-mailpit-http-router.middlewares=https-redirect@file"
+      #- "traefik.http.routers.toby-mailpit-http-router.middlewares=https-redirect@file"
       # HTTPS
-      - "traefik.http.routers.toby-mailpit-https-router.rule=Host(`toby-mailpit.blumilk.localhost`)"
+      - "traefik.http.routers.toby-mailpit-https-router.rule=Host(`${MAILPIT_DOCKER_HOST_NAME}`)"
       - "traefik.http.routers.toby-mailpit-https-router.entrypoints=websecure"
       - "traefik.http.routers.toby-mailpit-https-router.tls=true"
       # LOADBALANCER MAILPIT PORT
@@ -95,7 +105,7 @@ services:
       - ${DOCKER_MAILPIT_DASHBOARD_HOST_PORT:-8025}:8025
     networks:
       - toby-dev
-      - traefik-proxy-blumilk-local
+      - traefik-proxy-blumilk-local-environment
     restart: unless-stopped
 
   selenium:
@@ -110,7 +120,7 @@ services:
 networks:
   toby-dev:
     driver: bridge
-  traefik-proxy-blumilk-local:
+  traefik-proxy-blumilk-local-environment:
     external: true
 
 volumes:

--- a/environment/dev/app/supervisord.conf
+++ b/environment/dev/app/supervisord.conf
@@ -8,7 +8,7 @@ user = root
 nodaemon = true
 
 [program:unitd]
-command = unitd --no-daemon --control unix:/var/run/control.unit.sock
+command = unitd --user host-user --no-daemon --control unix:/var/run/control.unit.sock
 stdout_logfile = /dev/stdout
 stdout_logfile_maxbytes = 0
 stderr_logfile = /dev/stderr

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,6 @@
-import { defineConfig, loadEnv  } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import laravel from 'laravel-vite-plugin'
-import { networkInterfaces } from 'os'
 
 export default ({ mode }) => {
   process.env = { ...process.env, ...loadEnv(mode, process.cwd()) }
@@ -11,8 +10,11 @@ export default ({ mode }) => {
       outDir: './public/build/',
     },
     server: {
-      host: Object.values(networkInterfaces()).flat().find(i => i.family === 'IPv4' && !i.internal).address,
-      port: process.env.VITE_PORT,
+      host: true,
+      port: 5173,
+      strictPort: true,
+      origin: 'https://toby-vite-dev-server.blumilk.local.env',
+      cors: true, // Allow any origin
     },
     resolve: {
       alias: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,7 +13,7 @@ export default ({ mode }) => {
       host: true,
       port: 5173,
       strictPort: true,
-      origin: 'https://toby-vite-dev-server.blumilk.local.env',
+      origin: 'https://' + process.env.VITE_DEV_SERVER_DOCKER_HOST_NAME,
       cors: true, // Allow any origin
     },
     resolve: {


### PR DESCRIPTION
This pull request includes several changes aimed at updating environment configurations, improving Docker setup, and modifying the Vite configuration. The most important changes include updating environment variables in the `.env.example` file, modifying the `docker-compose.yml` file to use new host names, and updating the Vite configuration to enhance server setup.

### Environment Configuration Updates:
* Updated `APP_URL` and added new host name variables for Docker in the `.env.example` file. (`[[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL5-R5)`, `[[2]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL67-R71)`)

### Docker Setup Improvements:
* Modified `docker-compose.yml` to use new host names and added configurations for the Vite dev server and Mailpit service. (`[[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L11-R30)`, `[[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L32-R42)`, `[[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L82-R99)`, `[[4]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L98-R108)`, `[[5]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L113-R123)`)

### Vite Configuration Enhancements:
* Updated `vite.config.js` to use a fixed port and new origin, and removed the use of `networkInterfaces` for determining the host. (`[[1]](diffhunk://#diff-58e6f63d87181b1c6a8cb6e5f1691df04aa32854456efcd52ca71c8541375d26L4)`, `[[2]](diffhunk://#diff-58e6f63d87181b1c6a8cb6e5f1691df04aa32854456efcd52ca71c8541375d26L14-R17)`)

### Supervisor Configuration Update:
* Changed the user for the `unitd` command in `supervisord.conf` to `host-user`. (`[environment/dev/app/supervisord.confL11-R11](diffhunk://#diff-9d54e785b8647cea9638c551dad4b78fdeb24db0bc392d326aaa1c404291b391L11-R11)`)

 ---
 
 This PR updates local environment to be compatible with new Blumilk environment:
 - https://github.com/blumilksoftware/environment/pull/5

From now we will be able to develop apps with  Vite dev server via HTTPS and HTTP.
For more details check PR linked above.

Additionally:
- fixed issue with storage dir permissions for unit server (previously unit was run as `unit` user and has no access to the project files).