### PR TITLE
- prevent employee for creating time in lieu request

### DIFF
--- a/app/Enums/VacationType.php
+++ b/app/Enums/VacationType.php
@@ -8,18 +8,18 @@ use Illuminate\Support\Collection;
 
 enum VacationType: string
 {
-    case Vacation = "vacation";
-    case OnRequest = "vacation_on_request";
-    case Special = "special_vacation";
-    case Childcare = "childcare_vacation";
-    case Training = "training_vacation";
-    case Unpaid = "unpaid_vacation";
-    case Volunteering = "volunteering_vacation";
-    case TimeInLieu = "time_in_lieu";
-    case Sick = "sick_vacation";
-    case Absence = "absence";
     case RemoteWork = "remote_work";
+    case Absence = "absence";
+    case Vacation = "vacation";
+    case Sick = "sick_vacation";
+    case Special = "special_vacation";
     case Delegation = "delegation";
+    case TimeInLieu = "time_in_lieu";
+    case Unpaid = "unpaid_vacation";
+    case OnRequest = "vacation_on_request";
+    case Training = "training_vacation";
+    case Childcare = "childcare_vacation";
+    case Volunteering = "volunteering_vacation";
 
     public static function casesToSelect(): array
     {

--- a/config/vacation_types.php
+++ b/config/vacation_types.php
@@ -51,7 +51,6 @@ return [
             EmploymentForm::EmploymentContract,
         ],
         VacationTypeConfigRetriever::KEY_REQUEST_ALLOWED_FOR => [
-            Role::Employee,
             Role::Administrator,
             Role::AdministrativeApprover,
             Role::TechnicalApprover,

--- a/tests/Feature/VacationRequestTest.php
+++ b/tests/Feature/VacationRequestTest.php
@@ -852,15 +852,15 @@ class VacationRequestTest extends FeatureTestCase
             ])
             ->assertOk()
             ->assertJson([
-                ["label" => "Urlop wypoczynkowy", "value" => "vacation"],
-                ["label" => "Urlop na żądanie", "value" => "vacation_on_request"],
-                ["label" => "Urlop okolicznościowy", "value" => "special_vacation"],
-                ["label" => "Opieka nad dzieckiem (art. 188 kp)", "value" => "childcare_vacation"],
-                ["label" => "Urlop szkoleniowy", "value" => "training_vacation"],
-                ["label" => "Urlop bezpłatny", "value" => "unpaid_vacation"],
-                ["label" => "Wolontariat", "value" => "volunteering_vacation"],
-                ["label" => "Zwolnienie lekarskie", "value" => "sick_vacation"],
                 ["label" => "Praca zdalna", "value" => "remote_work"],
+                ["label" => "Urlop wypoczynkowy", "value" => "vacation"],
+                ["label" => "Zwolnienie lekarskie", "value" => "sick_vacation"],
+                ["label" => "Urlop okolicznościowy", "value" => "special_vacation"],
+                ["label" => "Urlop bezpłatny", "value" => "unpaid_vacation"],
+                ["label" => "Urlop na żądanie", "value" => "vacation_on_request"],
+                ["label" => "Urlop szkoleniowy", "value" => "training_vacation"],
+                ["label" => "Opieka nad dzieckiem (art. 188 kp)", "value" => "childcare_vacation"],
+                ["label" => "Wolontariat", "value" => "volunteering_vacation"],
             ]);
     }
 
@@ -877,16 +877,16 @@ class VacationRequestTest extends FeatureTestCase
             ])
             ->assertOk()
             ->assertJson([
-                ["label" => "Urlop wypoczynkowy", "value" => "vacation"],
-                ["label" => "Urlop na żądanie", "value" => "vacation_on_request"],
-                ["label" => "Urlop okolicznościowy", "value" => "special_vacation"],
-                ["label" => "Opieka nad dzieckiem (art. 188 kp)", "value" => "childcare_vacation"],
-                ["label" => "Urlop szkoleniowy", "value" => "training_vacation"],
-                ["label" => "Urlop bezpłatny", "value" => "unpaid_vacation"],
-                ["label" => "Wolontariat", "value" => "volunteering_vacation"],
-                ["label" => "Odbiór za święto", "value" => "time_in_lieu"],
-                ["label" => "Zwolnienie lekarskie", "value" => "sick_vacation"],
                 ["label" => "Praca zdalna", "value" => "remote_work"],
+                ["label" => "Urlop wypoczynkowy", "value" => "vacation"],
+                ["label" => "Zwolnienie lekarskie", "value" => "sick_vacation"],
+                ["label" => "Urlop okolicznościowy", "value" => "special_vacation"],
+                ["label" => "Odbiór za święto", "value" => "time_in_lieu"],
+                ["label" => "Urlop bezpłatny", "value" => "unpaid_vacation"],
+                ["label" => "Urlop na żądanie", "value" => "vacation_on_request"],
+                ["label" => "Urlop szkoleniowy", "value" => "training_vacation"],
+                ["label" => "Opieka nad dzieckiem (art. 188 kp)", "value" => "childcare_vacation"],
+                ["label" => "Wolontariat", "value" => "volunteering_vacation"],
             ]);
     }
 
@@ -903,17 +903,17 @@ class VacationRequestTest extends FeatureTestCase
             ])
             ->assertOk()
             ->assertJson([
-                ["label" => "Urlop wypoczynkowy", "value" => "vacation"],
-                ["label" => "Urlop na żądanie", "value" => "vacation_on_request"],
-                ["label" => "Urlop okolicznościowy", "value" => "special_vacation"],
-                ["label" => "Opieka nad dzieckiem (art. 188 kp)", "value" => "childcare_vacation"],
-                ["label" => "Urlop szkoleniowy", "value" => "training_vacation"],
-                ["label" => "Urlop bezpłatny", "value" => "unpaid_vacation"],
-                ["label" => "Wolontariat", "value" => "volunteering_vacation"],
-                ["label" => "Odbiór za święto", "value" => "time_in_lieu"],
-                ["label" => "Zwolnienie lekarskie", "value" => "sick_vacation"],
                 ["label" => "Praca zdalna", "value" => "remote_work"],
+                ["label" => "Urlop wypoczynkowy", "value" => "vacation"],
+                ["label" => "Zwolnienie lekarskie", "value" => "sick_vacation"],
+                ["label" => "Urlop okolicznościowy", "value" => "special_vacation"],
                 ["label" => "Delegacja", "value" => "delegation"],
+                ["label" => "Odbiór za święto", "value" => "time_in_lieu"],
+                ["label" => "Urlop bezpłatny", "value" => "unpaid_vacation"],
+                ["label" => "Urlop na żądanie", "value" => "vacation_on_request"],
+                ["label" => "Urlop szkoleniowy", "value" => "training_vacation"],
+                ["label" => "Opieka nad dzieckiem (art. 188 kp)", "value" => "childcare_vacation"],
+                ["label" => "Wolontariat", "value" => "volunteering_vacation"],
             ]);
     }
 
@@ -930,17 +930,17 @@ class VacationRequestTest extends FeatureTestCase
             ])
             ->assertOk()
             ->assertJson([
-                ["label" => "Urlop wypoczynkowy", "value" => "vacation"],
-                ["label" => "Urlop na żądanie", "value" => "vacation_on_request"],
-                ["label" => "Urlop okolicznościowy", "value" => "special_vacation"],
-                ["label" => "Opieka nad dzieckiem (art. 188 kp)", "value" => "childcare_vacation"],
-                ["label" => "Urlop szkoleniowy", "value" => "training_vacation"],
-                ["label" => "Urlop bezpłatny", "value" => "unpaid_vacation"],
-                ["label" => "Wolontariat", "value" => "volunteering_vacation"],
-                ["label" => "Odbiór za święto", "value" => "time_in_lieu"],
-                ["label" => "Zwolnienie lekarskie", "value" => "sick_vacation"],
                 ["label" => "Praca zdalna", "value" => "remote_work"],
+                ["label" => "Urlop wypoczynkowy", "value" => "vacation"],
+                ["label" => "Zwolnienie lekarskie", "value" => "sick_vacation"],
+                ["label" => "Urlop okolicznościowy", "value" => "special_vacation"],
                 ["label" => "Delegacja", "value" => "delegation"],
+                ["label" => "Odbiór za święto", "value" => "time_in_lieu"],
+                ["label" => "Urlop bezpłatny", "value" => "unpaid_vacation"],
+                ["label" => "Urlop na żądanie", "value" => "vacation_on_request"],
+                ["label" => "Urlop szkoleniowy", "value" => "training_vacation"],
+                ["label" => "Opieka nad dzieckiem (art. 188 kp)", "value" => "childcare_vacation"],
+                ["label" => "Wolontariat", "value" => "volunteering_vacation"],
             ]);
     }
 
@@ -956,8 +956,8 @@ class VacationRequestTest extends FeatureTestCase
             ])
             ->assertOk()
             ->assertJson([
-                ["label" => "Nieobecność", "value" => "absence"],
                 ["label" => "Praca zdalna", "value" => "remote_work"],
+                ["label" => "Nieobecność", "value" => "absence"],
             ]);
     }
 
@@ -973,8 +973,8 @@ class VacationRequestTest extends FeatureTestCase
             ])
             ->assertOk()
             ->assertJson([
-                ["label" => "Nieobecność", "value" => "absence"],
                 ["label" => "Praca zdalna", "value" => "remote_work"],
+                ["label" => "Nieobecność", "value" => "absence"],
             ]);
     }
 
@@ -990,8 +990,8 @@ class VacationRequestTest extends FeatureTestCase
             ])
             ->assertOk()
             ->assertJson([
-                ["label" => "Nieobecność", "value" => "absence"],
                 ["label" => "Praca zdalna", "value" => "remote_work"],
+                ["label" => "Nieobecność", "value" => "absence"],
             ]);
     }
 }

--- a/tests/Feature/VacationRequestTest.php
+++ b/tests/Feature/VacationRequestTest.php
@@ -859,7 +859,6 @@ class VacationRequestTest extends FeatureTestCase
                 ["label" => "Urlop szkoleniowy", "value" => "training_vacation"],
                 ["label" => "Urlop bezpłatny", "value" => "unpaid_vacation"],
                 ["label" => "Wolontariat", "value" => "volunteering_vacation"],
-                ["label" => "Odbiór za święto", "value" => "time_in_lieu"],
                 ["label" => "Zwolnienie lekarskie", "value" => "sick_vacation"],
                 ["label" => "Praca zdalna", "value" => "remote_work"],
             ]);


### PR DESCRIPTION
This pr prevents employees from creating time-in-lieu requests
Thanks to @MichalMyskow :wink: 

Also in this pr I changed vacation type order in create a vacation request form. Now types are ordered by most popular in our company