### PR TITLE
- fix summary birthday date on Slack

### DIFF
--- a/app/Actions/Slack/GenerateDailySummaryAction.php
+++ b/app/Actions/Slack/GenerateDailySummaryAction.php
@@ -28,10 +28,10 @@ class GenerateDailySummaryAction
                 "id" => $request->user->id,
                 "name" => $request->user->profile->fullName,
             ])->toArray(),
-            "birthdays" => $this->dailySummaryRetriever->getUpcomingBirthdays()->map(fn(User $user) => [
+            "birthdays" => $this->dailySummaryRetriever->getUpcomingBirthdays($day)->map(fn(User $user) => [
                 "id" => $user->id,
                 "name" => $user->profile->fullName,
-                "when" => $user->upcomingBirthday()->toDateTimeString(),
+                "when" => $user->upcomingBirthday($day)->toDateTimeString(),
             ])->toArray(),
         ]);
 

--- a/app/Actions/Slack/UpdateDailySummaryAction.php
+++ b/app/Actions/Slack/UpdateDailySummaryAction.php
@@ -33,10 +33,10 @@ class UpdateDailySummaryAction
                     "pending" => $request->state->equals(...VacationRequestStatesRetriever::pendingStates()),
                 ],
             )->toArray(),
-            "birthdays" => $this->dailySummaryRetriever->getUpcomingBirthdays()->map(fn(User $user) => [
+            "birthdays" => $this->dailySummaryRetriever->getUpcomingBirthdays($dailySummary->day)->map(fn(User $user) => [
                 "id" => $user->id,
                 "name" => $user->profile->fullName,
-                "when" => $user->upcomingBirthday()->toDateTimeString(),
+                "when" => $user->upcomingBirthday($dailySummary->day)->toDateTimeString(),
             ])->toArray(),
         ]);
 

--- a/app/Domain/DailySummaryRetriever.php
+++ b/app/Domain/DailySummaryRetriever.php
@@ -92,12 +92,12 @@ class DailySummaryRetriever
     /**
      * @return Collection<User>
      */
-    public function getUpcomingBirthdays(?int $limit = null): Collection
+    public function getUpcomingBirthdays(Carbon $date, ?int $limit = null): Collection
     {
         $users = User::query()
             ->whereRelation("profile", fn(Builder $query): Builder => $query->whereNotNull("birthday"))
             ->get()
-            ->sortBy(fn(User $user): int => (int)$user->upcomingBirthday()->diffInDays(Carbon::today()), descending: true);
+            ->sortBy(fn(User $user): int => (int)$user->upcomingBirthday($date)->diffInDays($date), descending: true);
 
         if ($limit) {
             return $users->take($limit);

--- a/app/Domain/DashboardAggregator.php
+++ b/app/Domain/DashboardAggregator.php
@@ -125,7 +125,7 @@ class DashboardAggregator
 
         $upcomingAbsences = $this->dailySummaryRetriever->getUpcomingAbsences($today);
         $upcomingRemoteDays = $this->dailySummaryRetriever->getUpcomingRemoteDays($today);
-        $upcomingBirthdays = $this->dailySummaryRetriever->getUpcomingBirthdays(3);
+        $upcomingBirthdays = $this->dailySummaryRetriever->getUpcomingBirthdays($today, 3);
 
         $upcomingHolidays = Holiday::query()
             ->whereDate("date", ">=", $today)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -201,18 +201,18 @@ class User extends Authenticatable implements NotifiableInterface
         };
     }
 
-    public function upcomingBirthday(): ?Carbon
+    public function upcomingBirthday(?Carbon $date = null): ?Carbon
     {
         if (!$this->profile->birthday) {
             return null;
         }
 
-        $today = Carbon::today();
+        $date ??= Carbon::today();
 
-        $birthday = $this->profile->birthday->setYear($today->year);
+        $birthday = $this->profile->birthday->setYear($date->year);
 
-        if (((int)$birthday->diffInDays()) > 0) {
-            $birthday->setYear($today->year + 1);
+        if (((int)$birthday->diffInDays($date)) > 0) {
+            $birthday->setYear($date->year + 1);
         }
 
         return $birthday;

--- a/environment/prod/app/Dockerfile
+++ b/environment/prod/app/Dockerfile
@@ -1,5 +1,5 @@
 # renovate: datasource=docker depName=php
-ARG PHP_VERSION=8.4.16
+ARG PHP_VERSION=8.4.11
 ARG PHP_MODULE_NAME=php${PHP_VERSION}
 # https://github.com/nginx/unit/tags
 ARG UNIT_VERSION=1.34.1-1


### PR DESCRIPTION
A bug was found (thanks @dawidrudnik :blush:) where birthdays were always displayed based on today's date, regardless of which day the daily summary was generated for. This caused birthdays to appear incorrectly 
in summaries created for past or future dates on Slack.