### PR TITLE
- Empty user list on bulk create for delegation and time in lieu, only on prod

### DIFF
--- a/app/Http/Controllers/VacationRequestController.php
+++ b/app/Http/Controllers/VacationRequestController.php
@@ -267,7 +267,6 @@ class VacationRequestController extends Controller
         foreach ($users as $user) {
             $typesByUser[$user->id] = VacationType::all()
                 ->filter(fn(VacationType $type): bool => $configRetriever->isAvailableFor($type, $user->profile->employment_form))
-                ->filter(fn(VacationType $type): bool => $configRetriever->isRequestAllowedFor($type, $request->user()->role))
                 ->pluck("value");
         }
 

--- a/tests/Feature/VacationRequestTest.php
+++ b/tests/Feature/VacationRequestTest.php
@@ -224,6 +224,65 @@ class VacationRequestTest extends FeatureTestCase
             "comment" => "Comment for the vacation request.",
         ]);
     }
+    public function testEmployeeWithPermissionSeesUsersForDelegationAndTimeInLieuInBulkCreate(): void
+    {
+        $creator = User::factory()
+            ->has(Profile::factory(["employment_form" => EmploymentForm::EmploymentContract]))
+            ->create();
+
+        $creator->givePermissionTo("createRequestsOnBehalfOfEmployee");
+
+        $targetEmployee = User::factory()
+            ->has(Profile::factory(["employment_form" => EmploymentForm::EmploymentContract]))
+            ->create();
+
+        $this->actingAs($creator)
+            ->get("/vacation/requests/bulk/create")
+            ->assertOk()
+            ->assertInertia(
+                fn(Assert $page) => $page
+                    ->component("VacationRequest/BulkCreate")
+                    ->where(
+                        "typesByUser.{$targetEmployee->id}",
+                        fn(array $types): bool => in_array(VacationType::Delegation->value, $types, true)
+                            && in_array(VacationType::TimeInLieu->value, $types, true)
+                            && in_array(VacationType::Vacation->value, $types, true),
+                    ),
+            );
+    }
+
+    public function testEmployeeWithPermissionCanCreateDelegationRequestForVisibleUser(): void
+    {
+        $creator = User::factory()
+            ->has(Profile::factory(["employment_form" => EmploymentForm::EmploymentContract]))
+            ->create();
+
+        $creator->givePermissionTo("createRequestsOnBehalfOfEmployee");
+
+        $targetEmployee = User::factory()
+            ->has(Profile::factory(["employment_form" => EmploymentForm::EmploymentContract]))
+            ->create();
+
+        $currentYear = Carbon::now()->year;
+
+        $this->actingAs($creator)
+            ->post("/vacation/requests/bulk", [
+                "users" => [$targetEmployee->id],
+                "type" => VacationType::Delegation->value,
+                "from" => Carbon::create($currentYear, 2, 7)->toDateString(),
+                "to" => Carbon::create($currentYear, 2, 11)->toDateString(),
+                "comment" => "Comment for the vacation request.",
+            ])
+            ->assertSessionHasNoErrors()
+            ->assertRedirect();
+
+        $this->assertDatabaseHas("vacation_requests", [
+            "user_id" => $targetEmployee->id,
+            "creator_id" => $creator->id,
+            "type" => VacationType::Delegation->value,
+            "state" => Approved::$name,
+        ]);
+    }
 
     public function testWhenBulkCreatingOnlyValidatedUsersHaveCreatedRequest(): void
     {

--- a/tests/Feature/VacationRequestTest.php
+++ b/tests/Feature/VacationRequestTest.php
@@ -224,6 +224,7 @@ class VacationRequestTest extends FeatureTestCase
             "comment" => "Comment for the vacation request.",
         ]);
     }
+
     public function testEmployeeWithPermissionSeesUsersForDelegationAndTimeInLieuInBulkCreate(): void
     {
         $creator = User::factory()

--- a/tests/Feature/VacationRequestTest.php
+++ b/tests/Feature/VacationRequestTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Storage;
@@ -245,9 +246,9 @@ class VacationRequestTest extends FeatureTestCase
                     ->component("VacationRequest/BulkCreate")
                     ->where(
                         "typesByUser.{$targetEmployee->id}",
-                        fn(array $types): bool => in_array(VacationType::Delegation->value, $types, true)
-                            && in_array(VacationType::TimeInLieu->value, $types, true)
-                            && in_array(VacationType::Vacation->value, $types, true),
+                        fn(Collection $types): bool => $types->contains(VacationType::Delegation->value)
+                            && $types->contains(VacationType::TimeInLieu->value)
+                            && $types->contains(VacationType::Vacation->value),
                     ),
             );
     }


### PR DESCRIPTION
Turned out `bulkCreate()` was filtering the employee list by the creator's role (`isRequestAllowedFor`) on top of `employment_form`, and time in lieu and delegation have a narrower allowed-roles list than the rest. Worked fine for people with role administrator/technical approver/administrative approver, but broke for anyone who got `createRequestsOnBehalfOfEmployee` granted directly while has role employee. 
